### PR TITLE
NIO byte buffer API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ script:
   - for input in ../fixtures/first-tiles/*; do ./jxrdecode --in-memory "$input" &> /dev/null ; done
 # Test jxrlib Java bindings (in memory and file to file)
   - mvn -f ../java/pom.xml test
+# Package and deploy
   - cd $TRAVIS_BUILD_DIR
   - mkdir -p $HOME/.m2
   - cat java/settings.xml | sed s/__MAVEN_SERVER_USERNAME__/$MAVEN_SERVER_USERNAME/g | sed s/__MAVEN_SERVER_PASSWORD__/$MAVEN_SERVER_PASSWORD/g > $HOME/.m2/settings.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ matrix:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; brew install swig ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]
-    then
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       cd /tmp/
       curl -s -J -O -k -L 'https://sourceforge.net/projects/swig/files/swig/swig-3.0.10/swig-3.0.10.tar.gz/download'
       tar zxf swig-3.0.10.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,8 @@ script:
   - cat java/settings.xml | sed s/__MAVEN_SERVER_USERNAME__/$MAVEN_SERVER_USERNAME/g | sed s/__MAVEN_SERVER_PASSWORD__/$MAVEN_SERVER_PASSWORD/g > $HOME/.m2/settings.xml
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd java/native-osx_64 ; else cd java/native-linux_64 ; fi
   - mvn package
-# Only deploy the clang compiled artifacts
-  - if [[ "$CXX" == "clang++" ]]; then mvn deploy ; fi
+# Only deploy the clang compiled artifacts when we're not building a PR
+  - if [[ "$CXX" == "clang++" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then mvn deploy ; fi
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_install:
       ./configure --prefix $HOME/swig/;
       make;
       make install;
+      cd $TRAVIS_BUILD_DIR;
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,7 @@ script:
   - set -e
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export SWIG=swig3.0 ; fi
   - make clean swig all
-  - mkdir -p $HOME/.m2
-  - cat java/settings.xml | sed s/__MAVEN_SERVER_USERNAME__/$MAVEN_SERVER_USERNAME/g | sed s/__MAVEN_SERVER_PASSWORD__/$MAVEN_SERVER_PASSWORD/g > $HOME/.m2/settings.xml
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd java/native-osx_64 ; else cd java/native-linux_64 ; fi
-  - mvn package
-# Only deploy the clang compiled artifacts
-  - if [[ "$CXX" == "clang++" ]]; then mvn deploy ; fi
 # Prepare to run tests
-  - cd $TRAVIS_BUILD_DIR
   - cd build
   - mkdir -p transcoded/C/ transcoded/C++/ transcoded/Java/
 # Test base jxrlib C library
@@ -55,6 +48,13 @@ script:
   - for input in ../fixtures/first-tiles/*; do ./jxrdecode --in-memory "$input" &> /dev/null ; done
 # Test jxrlib Java bindings (in memory and file to file)
   - mvn -f ../java/pom.xml test
+  - cd $TRAVIS_BUILD_DIR
+  - mkdir -p $HOME/.m2
+  - cat java/settings.xml | sed s/__MAVEN_SERVER_USERNAME__/$MAVEN_SERVER_USERNAME/g | sed s/__MAVEN_SERVER_PASSWORD__/$MAVEN_SERVER_PASSWORD/g > $HOME/.m2/settings.xml
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd java/native-osx_64 ; else cd java/native-linux_64 ; fi
+  - mvn package
+# Only deploy the clang compiled artifacts
+  - if [[ "$CXX" == "clang++" ]]; then mvn deploy ; fi
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,13 @@ matrix:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; brew install swig ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      cd /tmp/
-      curl -s -J -O -k -L 'https://sourceforge.net/projects/swig/files/swig/swig-3.0.10/swig-3.0.10.tar.gz/download'
-      tar zxf swig-3.0.10.tar.gz
-      cd swig-3.0.10
-      ./configure --prefix $HOME/swig/
-      make
-      make install
+      cd /tmp/;
+      curl -s -J -O -k -L 'https://sourceforge.net/projects/swig/files/swig/swig-3.0.10/swig-3.0.10.tar.gz/download';
+      tar zxf swig-3.0.10.tar.gz;
+      cd swig-3.0.10;
+      ./configure --prefix $HOME/swig/;
+      make;
+      make install;
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,11 @@ script:
 # Test jxrlib C++ wrapper library (in memory)
   - for input in ../fixtures/first-tiles/*; do ./jxrdecode --in-memory "$input" &> /dev/null ; done
 # Test jxrlib Java bindings (in memory and file to file)
-  - mvn -f ../java/pom.xml test
-# Package and deploy
   - cd $TRAVIS_BUILD_DIR
+  - mvn -f java/pom.xml test
+# Testing was successful, deploy the clang environment artifacts when on Linux and we're not building a PR
+  - if [[ "$CXX" == "clang++" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then mvn -f java/pom.xml deploy; fi
+# Package and deploy
   - mkdir -p $HOME/.m2
   - cat java/settings.xml | sed s/__MAVEN_SERVER_USERNAME__/$MAVEN_SERVER_USERNAME/g | sed s/__MAVEN_SERVER_PASSWORD__/$MAVEN_SERVER_PASSWORD/g > $HOME/.m2/settings.xml
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd java/native-osx_64 ; else cd java/native-linux_64 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,18 @@ env:
 matrix:
   include:
     - os: linux
-      dist: trusty
-      sudo: required
+      sudo: false
       addons:
         apt:
           packages:
-            - swig3.0
+            - pcre3-dev
       compiler: gcc
     - os: linux
-      dist: trusty
-      sudo: required
+      sudo: false
       addons:
         apt:
           packages:
-            - swig3.0
+            - pcre3-dev
       compiler: clang
     - os: osx
       osx_image: beta-xcode6.2  # Mac OS X 10.9
@@ -31,10 +29,20 @@ matrix:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; brew install swig ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]
+    then
+      cd /tmp/
+      curl -s -J -O -k -L 'https://sourceforge.net/projects/swig/files/swig/swig-3.0.10/swig-3.0.10.tar.gz/download'
+      tar zxf swig-3.0.10.tar.gz
+      cd swig-3.0.10
+      ./configure --prefix $HOME/swig/
+      make
+      make install
+    fi
 
 script:
   - set -e
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export SWIG=swig3.0 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export SWIG=$HOME/swig/bin/swig ; fi
   - make clean swig all
 # Prepare to run tests
   - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,12 @@ env:
 matrix:
   include:
     - os: linux
+      dist: trusty
+      sudo: required
       addons:
         apt:
           packages:
-            - swig
-            - gradle
+            - swig3.0
       compiler: gcc
     - os: linux
       dist: trusty
@@ -19,7 +20,7 @@ matrix:
       addons:
         apt:
           packages:
-            - swig
+            - swig3.0
       compiler: clang
     - os: osx
       osx_image: beta-xcode6.2  # Mac OS X 10.9
@@ -48,6 +49,7 @@ script:
 # Test base jxrlib C library
   - for input in ../fixtures/first-tiles/*; do bn=${input##*/} ; bn=${bn%.jxr} ; ./JxrDecApp -i "$input" -o "transcoded/C/$bn.tif" ; done
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=`pwd` ; else export LD_LIBRARY_PATH=`pwd` ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export SWIG=swig3.0 ; fi
 # Test jxrlib C++ wrapper library (file to file)
   - for input in ../fixtures/first-tiles/*; do bn=${input##*/} ; bn=${bn%.jxr} ; ./jxrdecode "$input" "transcoded/C++/$bn.tif" ; done
 # Test jxrlib C++ wrapper library (in memory)

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_install:
 
 script:
   - set -e
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export SWIG=swig3.0 ; fi
   - make clean swig all
   - mkdir -p $HOME/.m2
   - cat java/settings.xml | sed s/__MAVEN_SERVER_USERNAME__/$MAVEN_SERVER_USERNAME/g | sed s/__MAVEN_SERVER_PASSWORD__/$MAVEN_SERVER_PASSWORD/g > $HOME/.m2/settings.xml
@@ -49,7 +50,6 @@ script:
 # Test base jxrlib C library
   - for input in ../fixtures/first-tiles/*; do bn=${input##*/} ; bn=${bn%.jxr} ; ./JxrDecApp -i "$input" -o "transcoded/C/$bn.tif" ; done
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=`pwd` ; else export LD_LIBRARY_PATH=`pwd` ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export SWIG=swig3.0 ; fi
 # Test jxrlib C++ wrapper library (file to file)
   - for input in ../fixtures/first-tiles/*; do bn=${input##*/} ; bn=${bn%.jxr} ; ./jxrdecode "$input" "transcoded/C++/$bn.tif" ; done
 # Test jxrlib C++ wrapper library (in memory)

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ script:
   - if [[ "$CXX" == "clang++" ]]; then mvn deploy ; fi
 # Prepare to run tests
   - cd $TRAVIS_BUILD_DIR
-  - ./gradlew -b java/cli/build.gradle clean installDist
   - cd build
   - mkdir -p transcoded/C/ transcoded/C++/ transcoded/Java/
 # Test base jxrlib C library
@@ -54,9 +53,7 @@ script:
   - for input in ../fixtures/first-tiles/*; do bn=${input##*/} ; bn=${bn%.jxr} ; ./jxrdecode "$input" "transcoded/C++/$bn.tif" ; done
 # Test jxrlib C++ wrapper library (in memory)
   - for input in ../fixtures/first-tiles/*; do ./jxrdecode --in-memory "$input" &> /dev/null ; done
-# Test jxrlib Java bindings (file to file)
-  - for input in ../fixtures/first-tiles/*; do bn=${input##*/} ; bn=${bn%.jxr} ; ../java/cli/build/install/cli/bin/cli "$input" "transcoded/Java/$bn.tif" ; done
-# Test jxrlib Java bindings (in memory)
+# Test jxrlib Java bindings (in memory and file to file)
   - mvn -f ../java/pom.xml test
 
 cache:

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@
 build: all
 
 CC=cc
+SWIG?=swig
 
 JXR_VERSION=1.1
 
@@ -252,7 +253,7 @@ SRC_JAVA=$(wildcard $(DIR_SRC)/$(DIR_JAVA)/$(JAVA_PKG)/*.java)
 
 swig:
 	mkdir -p $(DIR_SRC)/$(DIR_JAVA)/$(JAVA_PKG)
-	swig -java -c++ -package ome.jxrlib -outdir $(DIR_SRC)/$(DIR_JAVA)/$(JAVA_PKG) -o $(DIR_SRC)/$(DIR_JAVA)/JXR_wrap.cxx java/JXR.i
+	$(SWIG) -java -c++ -package ome.jxrlib -outdir $(DIR_SRC)/$(DIR_JAVA)/$(JAVA_PKG) -o $(DIR_SRC)/$(DIR_JAVA)/JXR_wrap.cxx java/JXR.i
 
 $(DIR_BUILD)/libjxrjava.$(LIBSUFFIX): $(LIBRARIES) $(CXX_LIBRARIES)
 	@echo "Building JNI"

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@
 ##
 build: all
 
-CC=cc
 SWIG?=swig
 
 JXR_VERSION=1.1
@@ -91,13 +90,14 @@ CXXFLAGS:= $(CXXFLAGS) -g -O0 -DDEBUG
 endif
 
 ifeq ($(strip $(shell uname)), Darwin)
-  CC = clang
-	CXX = clang++
-	LIBSUFFIX = dylib
+  CC?=clang
+  CXX?=clang++
+  LIBSUFFIX = dylib
   PLATFORM = darwin
 else
-	CXX = g++
-	LIBSUFFIX = so
+  CC?=cc
+  CXX?=g++
+  LIBSUFFIX = so
   PLATFORM = linux
 endif
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,12 +14,12 @@ build:
 install:
   - cinst swig
 before_build:
-  - if not exist C:\Users\appveyor\.m2 mkdir C:\Users\appveyor\.m2
-  - ps: (Get-Content java\settings.xml) -replace '__MAVEN_SERVER_USERNAME__', "$env:MAVEN_SERVER_USERNAME" | %{$_ -replace '__MAVEN_SERVER_PASSWORD__', "$env:MAVEN_SERVER_PASSWORD"} | Out-File -encoding ASCII C:\Users\appveyor\.m2\settings.xml
   - mkdir java\target\swig\ome\jxrlib
   - swig.exe -java -c++ -package ome.jxrlib -outdir java\target\swig\ome\jxrlib -o java\target\swig\JXR_wrap.cxx java\JXR.i
-after_build:
-  - mvn -f java\native-windows_64\pom.xml package deploy
+on_success:
+  - IF NOT EXIST C:\Users\appveyor\.m2 mkdir C:\Users\appveyor\.m2
+  - ps: (Get-Content java\settings.xml) -replace '__MAVEN_SERVER_USERNAME__', "$env:MAVEN_SERVER_USERNAME" | %{$_ -replace '__MAVEN_SERVER_PASSWORD__', "$env:MAVEN_SERVER_PASSWORD"} | Out-File -encoding ASCII C:\Users\appveyor\.m2\settings.xml
+  - IF DEFINED APPVEYOR_PULL_REQUEST_NUMBER mvn -f java\native-windows_64\pom.xml package deploy
 artifacts:
   - path: 'java\native-windows_64\target\*.jar'
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,11 +16,13 @@ install:
 before_build:
   - mkdir java\target\swig\ome\jxrlib
   - swig.exe -java -c++ -package ome.jxrlib -outdir java\target\swig\ome\jxrlib -o java\target\swig\JXR_wrap.cxx java\JXR.i
+after_build:
+  - mvn -f java\native-windows_64\pom.xml package
 on_success:
   - IF NOT EXIST C:\Users\appveyor\.m2 mkdir C:\Users\appveyor\.m2
   - ps: (Get-Content java\settings.xml) -replace '__MAVEN_SERVER_USERNAME__', "$env:MAVEN_SERVER_USERNAME" | %{$_ -replace '__MAVEN_SERVER_PASSWORD__', "$env:MAVEN_SERVER_PASSWORD"} | Out-File -encoding ASCII C:\Users\appveyor\.m2\settings.xml
   - mvn -f java/pom.xml -DargLine="-Djava.library.path=vc14projects\Release\JXRJava\x64" test
-  - IF DEFINED APPVEYOR_PULL_REQUEST_NUMBER mvn -f java\native-windows_64\pom.xml package deploy
+  - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER mvn -f java\native-windows_64\pom.xml deploy
 artifacts:
   - path: 'java\native-windows_64\target\*.jar'
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ before_build:
 on_success:
   - IF NOT EXIST C:\Users\appveyor\.m2 mkdir C:\Users\appveyor\.m2
   - ps: (Get-Content java\settings.xml) -replace '__MAVEN_SERVER_USERNAME__', "$env:MAVEN_SERVER_USERNAME" | %{$_ -replace '__MAVEN_SERVER_PASSWORD__', "$env:MAVEN_SERVER_PASSWORD"} | Out-File -encoding ASCII C:\Users\appveyor\.m2\settings.xml
+  - mvn -f java/pom.xml -DargLine="-Djava.library.path=vc14projects\Release\JXRJava\x64" test
   - IF DEFINED APPVEYOR_PULL_REQUEST_NUMBER mvn -f java\native-windows_64\pom.xml package deploy
 artifacts:
   - path: 'java\native-windows_64\target\*.jar'

--- a/cpp/jxrdecode.cpp
+++ b/cpp/jxrdecode.cpp
@@ -55,7 +55,6 @@ void stream_data() {
   Factory factory;
   CodecFactory codecFactory;
   std::vector<unsigned char> bytes;
-  std::vector<char> decoded_bytes;
 
   std::cin.unsetf(std::ios_base::skipws);
   for(unsigned char val ; std::cin >> val ; ){
@@ -70,17 +69,24 @@ void stream_data() {
   codecFactory.decoderFromBytes(decoder, bytes);
   std::cerr << "Opened decoder with " << bytes.size() << " bytes" << std::endl;
 
+  unsigned int frameSize =
+    decoder.getWidth() * decoder.getHeight() * decoder.getBytesPerPixel();
+  unsigned char *image_buffer = new unsigned char[frameSize];
 
   unsigned int frameCount = decoder.getFrameCount();
   std::cerr << "Found " << frameCount << " frames" << std::endl;
 
   for(int i = 0 ; i < frameCount ; i++) {
     decoder.selectFrame(i);
-    decoded_bytes = decoder.getRawBytes();
+    decoder.getRawBytes(image_buffer);
+    std::vector<unsigned char> decoded_bytes(
+      image_buffer, image_buffer + frameSize);
 
     std::cerr << decoded_bytes.size() << " Bytes:" << std::endl;
     print_bytes(decoded_bytes, stdout);
   }
+
+  delete image_buffer;
 }
 
 void stream_file_bytes(std::string inputFile) {
@@ -98,23 +104,29 @@ void stream_file_bytes(std::string inputFile) {
 
   Factory factory;
   CodecFactory codecFactory;
-  std::vector<char> decoded_bytes;
 
   ImageDecoder decoder;
   codecFactory.decoderFromBytes(decoder, (unsigned char *)bytes.data(), bytes.size());
   std::cerr << "Opened decoder with " << bytes.size() << " bytes" << std::endl;
 
+  unsigned int frameSize =
+    decoder.getWidth() * decoder.getHeight() * decoder.getBytesPerPixel();
+  unsigned char *image_buffer = new unsigned char[frameSize];
 
   unsigned int frameCount = decoder.getFrameCount();
   std::cerr << "Found " << frameCount << " frames" << std::endl;
 
   for(int i = 0 ; i < frameCount ; i++) {
     decoder.selectFrame(i);
-    decoded_bytes = decoder.getRawBytes();
+    decoder.getRawBytes(image_buffer);
+    std::vector<unsigned char> decoded_bytes(
+      image_buffer, image_buffer + frameSize);
 
     std::cerr << decoded_bytes.size() << " Bytes:" << std::endl;
     print_bytes(decoded_bytes, stdout);
   }
+
+  delete image_buffer;
 }
 
 void stream_file(std::string inputFile) {
@@ -124,16 +136,24 @@ void stream_file(std::string inputFile) {
   ImageDecoder decoder = codecFactory.decoderFromFile(inputFile);
   std::cerr << "Opened decoder for file: " << inputFile << std::endl;
 
+  unsigned int frameSize =
+    decoder.getWidth() * decoder.getHeight() * decoder.getBytesPerPixel();
+  unsigned char *image_buffer = new unsigned char[frameSize];
+
   unsigned int frameCount = decoder.getFrameCount();
   std::cerr << "Found " << frameCount << " frames" << std::endl;
 
   for(int i = 0 ; i < frameCount ; i++) {
     decoder.selectFrame(i);
-    std::vector<char> bytes = decoder.getRawBytes();
+    decoder.getRawBytes(image_buffer);
+    std::vector<unsigned char> bytes(
+      image_buffer, image_buffer + frameSize);
 
     std::cerr << bytes.size() << " Bytes:" << std::endl;
     print_bytes(bytes);
   }
+
+  delete image_buffer;
 }
 
 void stream_file(std::string inputFile, long offset) {
@@ -143,16 +163,24 @@ void stream_file(std::string inputFile, long offset) {
   ImageDecoder decoder = codecFactory.decoderFromFile(inputFile, offset);
   std::cerr << "Opened decoder for file: " << inputFile << " at offset: " << offset << std::endl;
 
+  unsigned int frameSize =
+    decoder.getWidth() * decoder.getHeight() * decoder.getBytesPerPixel();
+  unsigned char *image_buffer = new unsigned char[frameSize];
+
   unsigned int frameCount = decoder.getFrameCount();
   std::cerr << "Found " << frameCount << " frames" << std::endl;
 
   for(int i = 0 ; i < frameCount ; i++) {
     decoder.selectFrame(i);
-    std::vector<char> bytes = decoder.getRawBytes();
+    decoder.getRawBytes(image_buffer);
+    std::vector<unsigned char> bytes(
+      image_buffer, image_buffer + frameSize);
 
     std::cerr << bytes.size() << " Bytes:" << std::endl;
     print_bytes(bytes);
   }
+
+  delete image_buffer;
 }
 
 void convert_file(std::string inputFile, std::string outputFile) {

--- a/cpp/jxrdecode.cpp
+++ b/cpp/jxrdecode.cpp
@@ -101,7 +101,7 @@ void stream_file_bytes(std::string inputFile) {
   CodecFactory codecFactory;
   std::vector<char> decoded_bytes;
 
-  ImageDecoder decoder = codecFactory.decoderFromBytes(bytes.data(), bytes.size());
+  ImageDecoder decoder = codecFactory.decoderFromBytes((unsigned char *)bytes.data(), bytes.size());
   std::cerr << "Opened decoder with " << bytes.size() << " bytes" << std::endl;
 
 

--- a/cpp/jxrdecode.cpp
+++ b/cpp/jxrdecode.cpp
@@ -133,7 +133,8 @@ void stream_file(std::string inputFile) {
   Factory factory;
   CodecFactory codecFactory;
 
-  ImageDecoder decoder = codecFactory.decoderFromFile(inputFile);
+  ImageDecoder decoder;
+  codecFactory.decoderFromFile(decoder, inputFile);
   std::cerr << "Opened decoder for file: " << inputFile << std::endl;
 
   unsigned int frameSize =
@@ -160,7 +161,8 @@ void stream_file(std::string inputFile, long offset) {
   Factory factory;
   CodecFactory codecFactory;
 
-  ImageDecoder decoder = codecFactory.decoderFromFile(inputFile, offset);
+  ImageDecoder decoder;
+  codecFactory.decoderFromFile(decoder, inputFile, offset);
   std::cerr << "Opened decoder for file: " << inputFile << " at offset: " << offset << std::endl;
 
   unsigned int frameSize =
@@ -187,7 +189,8 @@ void convert_file(std::string inputFile, std::string outputFile) {
   Factory factory;
   CodecFactory codecFactory;
 
-  ImageDecoder decoder = codecFactory.decoderFromFile(inputFile);
+  ImageDecoder decoder;
+  codecFactory.decoderFromFile(decoder, inputFile);
   std::cerr << "Opened decoder for file: " << inputFile << std::endl;
 
   unsigned int frameCount = decoder.getFrameCount();

--- a/cpp/jxrdecode.cpp
+++ b/cpp/jxrdecode.cpp
@@ -66,7 +66,8 @@ void stream_data() {
   print_bytes(bytes);
   std::cerr << std::endl;
 
-  ImageDecoder decoder = codecFactory.decoderFromBytes(bytes);
+  ImageDecoder decoder;
+  codecFactory.decoderFromBytes(decoder, bytes);
   std::cerr << "Opened decoder with " << bytes.size() << " bytes" << std::endl;
 
 
@@ -80,8 +81,6 @@ void stream_data() {
     std::cerr << decoded_bytes.size() << " Bytes:" << std::endl;
     print_bytes(decoded_bytes, stdout);
   }
-
-  decoder.close();
 }
 
 void stream_file_bytes(std::string inputFile) {
@@ -101,7 +100,8 @@ void stream_file_bytes(std::string inputFile) {
   CodecFactory codecFactory;
   std::vector<char> decoded_bytes;
 
-  ImageDecoder decoder = codecFactory.decoderFromBytes((unsigned char *)bytes.data(), bytes.size());
+  ImageDecoder decoder;
+  codecFactory.decoderFromBytes(decoder, (unsigned char *)bytes.data(), bytes.size());
   std::cerr << "Opened decoder with " << bytes.size() << " bytes" << std::endl;
 
 
@@ -115,8 +115,6 @@ void stream_file_bytes(std::string inputFile) {
     std::cerr << decoded_bytes.size() << " Bytes:" << std::endl;
     print_bytes(decoded_bytes, stdout);
   }
-
-  decoder.close();
 }
 
 void stream_file(std::string inputFile) {
@@ -136,8 +134,6 @@ void stream_file(std::string inputFile) {
     std::cerr << bytes.size() << " Bytes:" << std::endl;
     print_bytes(bytes);
   }
-
-  decoder.close();
 }
 
 void stream_file(std::string inputFile, long offset) {
@@ -157,8 +153,6 @@ void stream_file(std::string inputFile, long offset) {
     std::cerr << bytes.size() << " Bytes:" << std::endl;
     print_bytes(bytes);
   }
-
-  decoder.close();
 }
 
 void convert_file(std::string inputFile, std::string outputFile) {
@@ -185,8 +179,6 @@ void convert_file(std::string inputFile, std::string outputFile) {
     encoder.writeSource(converter);
     encoder.close();
   }
-
-  decoder.close();
 }
 
 int main(int argc, char* argv[]) {

--- a/cpp/jxrdecode.cpp
+++ b/cpp/jxrdecode.cpp
@@ -71,22 +71,18 @@ void stream_data() {
 
   unsigned int frameSize =
     decoder.getWidth() * decoder.getHeight() * decoder.getBytesPerPixel();
-  unsigned char *image_buffer = new unsigned char[frameSize];
+  std::vector<unsigned char> decodedBytes(frameSize);
 
   unsigned int frameCount = decoder.getFrameCount();
   std::cerr << "Found " << frameCount << " frames" << std::endl;
 
   for(int i = 0 ; i < frameCount ; i++) {
     decoder.selectFrame(i);
-    decoder.getRawBytes(image_buffer);
-    std::vector<unsigned char> decoded_bytes(
-      image_buffer, image_buffer + frameSize);
+    decoder.getRawBytes(decodedBytes.data());
 
-    std::cerr << decoded_bytes.size() << " Bytes:" << std::endl;
-    print_bytes(decoded_bytes, stdout);
+    std::cerr << decodedBytes.size() << " Bytes:" << std::endl;
+    print_bytes(decodedBytes, stdout);
   }
-
-  delete image_buffer;
 }
 
 void stream_file_bytes(std::string inputFile) {
@@ -111,22 +107,18 @@ void stream_file_bytes(std::string inputFile) {
 
   unsigned int frameSize =
     decoder.getWidth() * decoder.getHeight() * decoder.getBytesPerPixel();
-  unsigned char *image_buffer = new unsigned char[frameSize];
+  std::vector<unsigned char> decodedBytes(frameSize);
 
   unsigned int frameCount = decoder.getFrameCount();
   std::cerr << "Found " << frameCount << " frames" << std::endl;
 
   for(int i = 0 ; i < frameCount ; i++) {
     decoder.selectFrame(i);
-    decoder.getRawBytes(image_buffer);
-    std::vector<unsigned char> decoded_bytes(
-      image_buffer, image_buffer + frameSize);
+    decoder.getRawBytes(decodedBytes.data());
 
-    std::cerr << decoded_bytes.size() << " Bytes:" << std::endl;
-    print_bytes(decoded_bytes, stdout);
+    std::cerr << decodedBytes.size() << " Bytes:" << std::endl;
+    print_bytes(decodedBytes, stdout);
   }
-
-  delete image_buffer;
 }
 
 void stream_file(std::string inputFile) {
@@ -139,22 +131,18 @@ void stream_file(std::string inputFile) {
 
   unsigned int frameSize =
     decoder.getWidth() * decoder.getHeight() * decoder.getBytesPerPixel();
-  unsigned char *image_buffer = new unsigned char[frameSize];
+  std::vector<unsigned char> bytes(frameSize);
 
   unsigned int frameCount = decoder.getFrameCount();
   std::cerr << "Found " << frameCount << " frames" << std::endl;
 
   for(int i = 0 ; i < frameCount ; i++) {
     decoder.selectFrame(i);
-    decoder.getRawBytes(image_buffer);
-    std::vector<unsigned char> bytes(
-      image_buffer, image_buffer + frameSize);
+    decoder.getRawBytes(bytes.data());
 
     std::cerr << bytes.size() << " Bytes:" << std::endl;
     print_bytes(bytes);
   }
-
-  delete image_buffer;
 }
 
 void stream_file(std::string inputFile, long offset) {
@@ -167,22 +155,18 @@ void stream_file(std::string inputFile, long offset) {
 
   unsigned int frameSize =
     decoder.getWidth() * decoder.getHeight() * decoder.getBytesPerPixel();
-  unsigned char *image_buffer = new unsigned char[frameSize];
+  std::vector<unsigned char> bytes(frameSize);
 
   unsigned int frameCount = decoder.getFrameCount();
   std::cerr << "Found " << frameCount << " frames" << std::endl;
 
   for(int i = 0 ; i < frameCount ; i++) {
     decoder.selectFrame(i);
-    decoder.getRawBytes(image_buffer);
-    std::vector<unsigned char> bytes(
-      image_buffer, image_buffer + frameSize);
+    decoder.getRawBytes(bytes.data());
 
     std::cerr << bytes.size() << " Bytes:" << std::endl;
     print_bytes(bytes);
   }
-
-  delete image_buffer;
 }
 
 void convert_file(std::string inputFile, std::string outputFile) {

--- a/cpp/lib/CodecFactory.cpp
+++ b/cpp/lib/CodecFactory.cpp
@@ -105,12 +105,12 @@ namespace jxrlib {
   }
 
   ImageDecoder CodecFactory::decoderFromBytes(std::vector<unsigned char> data) {
-    return decoderFromBytes((char *)data.data(), data.size());
+    return decoderFromBytes(data.data(), data.size());
   }
 
-  ImageDecoder CodecFactory::decoderFromBytes(char *bytes, size_t len) {
+  ImageDecoder CodecFactory::decoderFromBytes(unsigned char *bytes, size_t len) {
     ImageDecoder decoder;
-    Stream dataStream((unsigned char *)bytes, len);
+    Stream dataStream(bytes, len);
     const PKIID *pIID = NULL;
 
     Call(GetImageDecodeIID((const char *)".jxr", &pIID));

--- a/cpp/lib/CodecFactory.cpp
+++ b/cpp/lib/CodecFactory.cpp
@@ -54,19 +54,16 @@ namespace jxrlib {
     }
   }
 
-  ImageDecoder CodecFactory::decoderFromFile(std::string inputFile) {
-    ImageDecoder decoder;
+  void CodecFactory::decoderFromFile(ImageDecoder &decoder, std::string inputFile) {
     Call(pCodecFactory->CreateDecoderFromFile(inputFile.c_str(), &decoder.pDecoder));
     decoder.initialize();
-    return decoder;
+    return;
   Cleanup:
     std::string msg = "ERROR: Unable to create decoder from file: " + inputFile;
     throw FormatError(msg);
   }
 
-  ImageDecoder CodecFactory::decoderFromFile(std::string inputFile, long offset) {
-    ImageDecoder decoder;
-
+  void CodecFactory::decoderFromFile(ImageDecoder &decoder, std::string inputFile, long offset) {
     int err = 0;
     std::string ext = ".jxr";
     const PKIID *pIID = NULL;
@@ -100,7 +97,7 @@ namespace jxrlib {
     decoder.pDecoder->fStreamOwner = !0;
     decoder.initialize();
 
-    return decoder;
+    return;
   Cleanup:
     std::stringstream msg;
     msg << "ERROR: Unable to create decoder from file: " << inputFile << " at offset: " << offset;

--- a/cpp/lib/CodecFactory.cpp
+++ b/cpp/lib/CodecFactory.cpp
@@ -46,6 +46,9 @@ namespace jxrlib {
   }
 
   CodecFactory::~CodecFactory() {
+#ifdef DEBUG
+    std::cerr << "CodecFactory " << this << " destructor!" << std::endl;
+#endif
     if (pCodecFactory) {
       pCodecFactory->Release(&pCodecFactory);
     }
@@ -104,19 +107,18 @@ namespace jxrlib {
     throw FormatError(msg.str().c_str());
   }
 
-  ImageDecoder CodecFactory::decoderFromBytes(std::vector<unsigned char> data) {
-    return decoderFromBytes(data.data(), data.size());
+  void CodecFactory::decoderFromBytes(ImageDecoder &decoder, std::vector<unsigned char> data) {
+    decoderFromBytes(decoder, data.data(), data.size());
   }
 
-  ImageDecoder CodecFactory::decoderFromBytes(unsigned char *bytes, size_t len) {
-    ImageDecoder decoder;
+  void CodecFactory::decoderFromBytes(ImageDecoder &decoder, unsigned char *bytes, size_t len) {
     Stream dataStream(bytes, len);
     const PKIID *pIID = NULL;
 
     Call(GetImageDecodeIID((const char *)".jxr", &pIID));
     Call(PKCodecFactory_CreateCodec(pIID, (void**)&decoder.pDecoder));
     decoder.initialize(dataStream);
-    return decoder;
+    return;
   Cleanup:
     throw FormatError("ERROR: Unable to create decoder from bytes in memory");
   }

--- a/cpp/lib/CodecFactory.hpp
+++ b/cpp/lib/CodecFactory.hpp
@@ -39,7 +39,7 @@ namespace jxrlib {
     ImageDecoder decoderFromFile(std::string inputFile);
     ImageDecoder decoderFromFile(std::string inputFile, long offset);
     ImageDecoder decoderFromBytes(std::vector<unsigned char> data);
-    ImageDecoder decoderFromBytes(char *bytes, size_t len);
+    ImageDecoder decoderFromBytes(unsigned char *bytes, size_t len);
     FormatConverter createFormatConverter(ImageDecoder &imageDecoder,
                                           std::string extension);
   };

--- a/cpp/lib/CodecFactory.hpp
+++ b/cpp/lib/CodecFactory.hpp
@@ -36,11 +36,11 @@ namespace jxrlib {
     CodecFactory();
     ~CodecFactory();
 
-    ImageDecoder decoderFromFile(std::string inputFile);
-    ImageDecoder decoderFromFile(std::string inputFile, long offset);
-    void decoderFromBytes(ImageDecoder &imageDecoder, std::vector<unsigned char> data);
-    void decoderFromBytes(ImageDecoder &imageDecoder, unsigned char *bytes, size_t len);
-    FormatConverter createFormatConverter(ImageDecoder &imageDecoder,
+    void decoderFromFile(ImageDecoder &decoder, std::string inputFile);
+    void decoderFromFile(ImageDecoder &decoder, std::string inputFile, long offset);
+    void decoderFromBytes(ImageDecoder &decoder, std::vector<unsigned char> data);
+    void decoderFromBytes(ImageDecoder &decoder, unsigned char *bytes, size_t len);
+    FormatConverter createFormatConverter(ImageDecoder &decoder,
                                           std::string extension);
   };
 

--- a/cpp/lib/CodecFactory.hpp
+++ b/cpp/lib/CodecFactory.hpp
@@ -38,8 +38,8 @@ namespace jxrlib {
 
     ImageDecoder decoderFromFile(std::string inputFile);
     ImageDecoder decoderFromFile(std::string inputFile, long offset);
-    ImageDecoder decoderFromBytes(std::vector<unsigned char> data);
-    ImageDecoder decoderFromBytes(unsigned char *bytes, size_t len);
+    void decoderFromBytes(ImageDecoder &imageDecoder, std::vector<unsigned char> data);
+    void decoderFromBytes(ImageDecoder &imageDecoder, unsigned char *bytes, size_t len);
     FormatConverter createFormatConverter(ImageDecoder &imageDecoder,
                                           std::string extension);
   };

--- a/cpp/lib/Factory.cpp
+++ b/cpp/lib/Factory.cpp
@@ -20,6 +20,9 @@
 
 #include "Factory.hpp"
 
+#include <iostream>
+#include <fstream>
+
 #include "FormatError.hpp"
 #include "windowsmediaphoto.h"
 
@@ -33,6 +36,9 @@ namespace jxrlib {
   }
 
   Factory::~Factory() {
+#ifdef DEBUG
+    std::cerr << "Factory " << this << " destructor!" << std::endl;
+#endif
     if (pFactory) {
       pFactory->Release(&pFactory);
     }

--- a/cpp/lib/ImageDecoder.cpp
+++ b/cpp/lib/ImageDecoder.cpp
@@ -142,7 +142,7 @@ namespace jxrlib {
   }
 
   bool ImageDecoder::getBlackWhite() {
-    return pDecoder->WMP.wmiSCP.bBlackWhite;
+    return pDecoder->WMP.wmiSCP.bBlackWhite == TRUE;
   }
 
   unsigned int ImageDecoder::getWidth() {

--- a/cpp/lib/ImageDecoder.cpp
+++ b/cpp/lib/ImageDecoder.cpp
@@ -154,19 +154,13 @@ namespace jxrlib {
     throw FormatError("ERROR: Could not get decoder resolution");
   }
 
-  std::vector<char> ImageDecoder::getRawBytes() {
+  void ImageDecoder::getRawBytes(unsigned char *image_buffer) {
     ERR err = WMP_errSuccess;
     int width, height;
     PKRect rc;
-    size_t buf_size;
-    unsigned char *image_buffer;
-    std::vector<char> ret;
 
     size_t bytesPerPixel = getBytesPerPixel();
     Call(pDecoder->GetSize(pDecoder, &width, &height));
-    buf_size = width * height * bytesPerPixel;
-    image_buffer = (unsigned char *)malloc(buf_size);
-    ret.resize(buf_size);
 
     rc.X = 0;
     rc.Y = 0;
@@ -174,10 +168,7 @@ namespace jxrlib {
     rc.Height = height;
 
     Call(pDecoder->Copy(pDecoder, &rc, image_buffer, width * bytesPerPixel));
-    ret.assign(image_buffer, image_buffer + buf_size);
-    free(image_buffer);
-
-    return ret;
+    return;
   Cleanup:
     std::stringstream msg;
     msg << "ERROR: Could not get image bytes: " << err;

--- a/cpp/lib/ImageDecoder.cpp
+++ b/cpp/lib/ImageDecoder.cpp
@@ -20,6 +20,8 @@
 
 #include "ImageDecoder.hpp"
 
+#include <fstream>
+#include <iostream>
 #include <sstream>
 #include <string>
 
@@ -30,6 +32,15 @@
 #include "Stream.hpp"
 
 namespace jxrlib {
+
+  ImageDecoder::~ImageDecoder() {
+#ifdef DEBUG
+    std::cerr << "ImageDecoder " << this << " destructor!" << std::endl;
+#endif
+    if (pDecoder) {
+      pDecoder->Release(&pDecoder);
+    }
+  }
 
   void ImageDecoder::initialize() {
     // set default color format
@@ -141,10 +152,6 @@ namespace jxrlib {
     return res;
   Cleanup:
     throw FormatError("ERROR: Could not get decoder resolution");
-  }
-
-  void ImageDecoder::close() {
-    pDecoder->Release(&pDecoder);
   }
 
   std::vector<char> ImageDecoder::getRawBytes() {

--- a/cpp/lib/ImageDecoder.cpp
+++ b/cpp/lib/ImageDecoder.cpp
@@ -137,11 +137,25 @@ namespace jxrlib {
     throw FormatError(errMsg);
   }
 
-  GUID ImageDecoder::getGUIDPixFormat() { return pDecoder->guidPixFormat; }
-  bool ImageDecoder::getBlackWhite() { return pDecoder->WMP.wmiSCP.bBlackWhite; }
-  unsigned int ImageDecoder::getWidth() { return pDecoder->WMP.wmiI.cROIWidth; }
-  unsigned int ImageDecoder::getHeight() { return pDecoder->WMP.wmiI.cROIHeight; }
-  unsigned int ImageDecoder::getBytesPerPixel() { return pDecoder->WMP.wmiI.cBitsPerUnit / 8; }
+  GUID ImageDecoder::getGUIDPixFormat() {
+    return pDecoder->guidPixFormat;
+  }
+
+  bool ImageDecoder::getBlackWhite() {
+    return pDecoder->WMP.wmiSCP.bBlackWhite;
+  }
+
+  unsigned int ImageDecoder::getWidth() {
+    return pDecoder->WMP.wmiI.cROIWidth;
+  }
+
+  unsigned int ImageDecoder::getHeight() {
+    return pDecoder->WMP.wmiI.cROIHeight;
+  }
+
+  unsigned int ImageDecoder::getBytesPerPixel() {
+    return pDecoder->WMP.wmiI.cBitsPerUnit / 8;
+  }
 
   Resolution ImageDecoder::getResolution() {
     float rX = 0.0, rY = 0.0;

--- a/cpp/lib/ImageDecoder.cpp
+++ b/cpp/lib/ImageDecoder.cpp
@@ -145,15 +145,15 @@ namespace jxrlib {
     return pDecoder->WMP.wmiSCP.bBlackWhite == TRUE;
   }
 
-  unsigned int ImageDecoder::getWidth() {
+  size_t ImageDecoder::getWidth() {
     return pDecoder->WMP.wmiI.cROIWidth;
   }
 
-  unsigned int ImageDecoder::getHeight() {
+  size_t ImageDecoder::getHeight() {
     return pDecoder->WMP.wmiI.cROIHeight;
   }
 
-  unsigned int ImageDecoder::getBytesPerPixel() {
+  size_t ImageDecoder::getBytesPerPixel() {
     return pDecoder->WMP.wmiI.cBitsPerUnit / 8;
   }
 
@@ -170,10 +170,10 @@ namespace jxrlib {
 
   void ImageDecoder::getRawBytes(unsigned char *image_buffer) {
     ERR err = WMP_errSuccess;
-    int width, height;
+	I32 width, height, bytesPerPixel;
     PKRect rc;
 
-    size_t bytesPerPixel = getBytesPerPixel();
+    bytesPerPixel = (I32) getBytesPerPixel();
     Call(pDecoder->GetSize(pDecoder, &width, &height));
 
     rc.X = 0;

--- a/cpp/lib/ImageDecoder.hpp
+++ b/cpp/lib/ImageDecoder.hpp
@@ -34,6 +34,7 @@ namespace jxrlib {
     friend class CodecFactory;
   public:
     ImageDecoder() : pDecoder(NULL), err(WMP_errSuccess) {};
+    ~ImageDecoder();
     void initialize();
     void initialize(Stream &data);
 
@@ -47,8 +48,6 @@ namespace jxrlib {
     unsigned int getBytesPerPixel();
     Resolution getResolution();
     std::vector<char> getRawBytes();
-
-    void close();
   };
 
 } // namespace jxrlib

--- a/cpp/lib/ImageDecoder.hpp
+++ b/cpp/lib/ImageDecoder.hpp
@@ -47,7 +47,7 @@ namespace jxrlib {
     unsigned int getHeight();
     unsigned int getBytesPerPixel();
     Resolution getResolution();
-    std::vector<char> getRawBytes();
+    void getRawBytes(unsigned char *image_buffer);
   };
 
 } // namespace jxrlib

--- a/cpp/lib/ImageDecoder.hpp
+++ b/cpp/lib/ImageDecoder.hpp
@@ -43,9 +43,9 @@ namespace jxrlib {
 
     GUID getGUIDPixFormat();
     bool getBlackWhite();
-    unsigned int getWidth();
-    unsigned int getHeight();
-    unsigned int getBytesPerPixel();
+    size_t getWidth();
+    size_t getHeight();
+    size_t getBytesPerPixel();
     Resolution getResolution();
     void getRawBytes(unsigned char *image_buffer);
   };

--- a/cpp/lib/ImageEncoder.cpp
+++ b/cpp/lib/ImageEncoder.cpp
@@ -46,7 +46,7 @@ namespace jxrlib {
 
     // Set size
     Call(pEncoder->SetSize(
-		pEncoder, (I32)decoder.getWidth(), (I32)decoder.getHeight()));
+        pEncoder, (I32)decoder.getWidth(), (I32)decoder.getHeight()));
     decoderRes = decoder.getResolution();
     Call(pEncoder->SetResolution(pEncoder, decoderRes.X, decoderRes.Y));
     return;

--- a/cpp/lib/ImageEncoder.cpp
+++ b/cpp/lib/ImageEncoder.cpp
@@ -45,7 +45,8 @@ namespace jxrlib {
     pEncoder->WMP.wmiSCP.bBlackWhite = decoder.getBlackWhite();
 
     // Set size
-    Call(pEncoder->SetSize(pEncoder, decoder.getWidth(), decoder.getHeight()));
+    Call(pEncoder->SetSize(
+		pEncoder, (I32)decoder.getWidth(), (I32)decoder.getHeight()));
     decoderRes = decoder.getResolution();
     Call(pEncoder->SetResolution(pEncoder, decoderRes.X, decoderRes.Y));
     return;

--- a/cpp/lib/Stream.cpp
+++ b/cpp/lib/Stream.cpp
@@ -26,10 +26,8 @@
 
 namespace jxrlib {
 
-  Stream::Stream(unsigned char *bytes, size_t len) : pStream(NULL), data(NULL), err(WMP_errSuccess) {
-    data = (unsigned char *)std::malloc(len);
-    std::memcpy(data, bytes, len);
-    Call(CreateWS_Memory(&pStream, data, len));
+  Stream::Stream(unsigned char *bytes, size_t len) : pStream(NULL), err(WMP_errSuccess) {
+    Call(CreateWS_Memory(&pStream, bytes, len));
     return;
   Cleanup:
     throw FormatError("ERROR: Unable to initialize stream with bytes");

--- a/cpp/lib/Stream.hpp
+++ b/cpp/lib/Stream.hpp
@@ -28,9 +28,8 @@ namespace jxrlib {
 
   struct Stream {
     struct WMPStream *pStream;
-    unsigned char *data;
     ERR err;
-    Stream() : pStream(NULL), data(NULL), err(WMP_errSuccess) {}
+    Stream() : pStream(NULL), err(WMP_errSuccess) {}
     Stream(unsigned char *bytes, size_t len);
   };
 

--- a/cpp/lib/Stream.hpp
+++ b/cpp/lib/Stream.hpp
@@ -30,6 +30,9 @@ namespace jxrlib {
     struct WMPStream *pStream;
     ERR err;
     Stream() : pStream(NULL), err(WMP_errSuccess) {}
+    // No destructor required as resources are cleaned up by
+    // PKImageDecode_Release
+    //~Stream();
     Stream(unsigned char *bytes, size_t len);
   };
 

--- a/java/JXR.i
+++ b/java/JXR.i
@@ -31,25 +31,7 @@ typedef struct {
 
 namespace jxrlib {
 
-  %typemap(javaclassmodifiers) CodecFactory "class"
-  class CodecFactory {
-  public:
-    void decoderFromFile(jxrlib::ImageDecoder& decoder, std::string inputFile);
-    void decoderFromBytes(jxrlib::ImageDecoder& decoder, unsigned char *NIOBUFFER, size_t len);
-    jxrlib::FormatConverter createFormatConverter(jxrlib::ImageDecoder& decoder, std::string extension);
-  };
-
-  %typemap(javaclassmodifiers) Factory "class"
-  class Factory {
-  public:
-    jxrlib::Stream createStreamFromFilename(std::string filename);
-  };
-
-  %typemap(javaclassmodifiers) FormatConverter "class"
-  class FormatConverter {};
-
-  %typemap(javaclassmodifiers) FormatError "class"
-  %typemap(javabase) FormatError "java.lang.Exception";
+  %typemap(javabase) FormatError "java.lang.Exception"
   %rename(getMessage) FormatError::what();
   class FormatError {
   public:
@@ -57,27 +39,53 @@ namespace jxrlib {
     std::string what();
   };
 
+  %typemap(throws) FormatError {
+    jclass exception = jenv->FindClass("ome/jxrlib/FormatError");
+    if (exception) {
+      jenv->ThrowNew(exception, $1.what());
+    }
+    return $null;
+  }
+
+  %typemap(javaclassmodifiers) CodecFactory "class"
+  class CodecFactory {
+  public:
+    void decoderFromFile(jxrlib::ImageDecoder& decoder, std::string inputFile) throw(FormatError);
+    void decoderFromBytes(jxrlib::ImageDecoder& decoder, unsigned char *NIOBUFFER, size_t len) throw(FormatError);
+    jxrlib::FormatConverter createFormatConverter(jxrlib::ImageDecoder& decoder, std::string extension) throw(FormatError);
+  };
+
+  %typemap(javaclassmodifiers) Factory "class"
+  class Factory {
+  public:
+    Factory() throw(FormatError);
+    jxrlib::Stream createStreamFromFilename(std::string filename) throw(FormatError);;
+  };
+
+  %typemap(javaclassmodifiers) FormatConverter "class"
+  class FormatConverter {};
+
   %typemap(javaclassmodifiers) ImageDecoder "class"
   class ImageDecoder {
   public:
-    void initialize();
-    unsigned int getFrameCount();
-    void selectFrame(unsigned int frameNum);
+    void initialize() throw(FormatError);
+    unsigned int getFrameCount() throw(FormatError);
+    void selectFrame(unsigned int frameNum) throw(FormatError);
     GUID getGUIDPixFormat();
     bool getBlackWhite();
     size_t getWidth();
     size_t getHeight();
     size_t getBytesPerPixel();
-    jxrlib::Resolution getResolution();
-    void getRawBytes(unsigned char *NIOBUFFER);
+    jxrlib::Resolution getResolution() throw(FormatError);
+    void getRawBytes(unsigned char *NIOBUFFER) throw(FormatError);
   };
 
   %typemap(javaclassmodifiers) ImageEncoder "class"
   class ImageEncoder {
   public:
-    ImageEncoder(jxrlib::Stream encodeStream, std::string extension);
-    void initializeWithDecoder(jxrlib::ImageDecoder& decoder);
-    void writeSource(jxrlib::FormatConverter& converter);
+    ImageEncoder(jxrlib::Stream encodeStream, std::string extension) throw(FormatError);
+    void initializeWithDecoder(jxrlib::ImageDecoder& decoder) throw(FormatError);
+    void writeSource(jxrlib::FormatConverter& converter) throw(FormatError);
     void close();
   };
 

--- a/java/JXR.i
+++ b/java/JXR.i
@@ -41,7 +41,7 @@ namespace jxrlib {
   class CodecFactory {
   public:
     jxrlib::ImageDecoder decoderFromFile(std::string inputFile);
-    jxrlib::ImageDecoder decoderFromBytes(unsigned char *NIOBUFFER, size_t len);
+    void decoderFromBytes(jxrlib::ImageDecoder& imageDecoder, unsigned char *NIOBUFFER, size_t len);
     jxrlib::FormatConverter createFormatConverter(jxrlib::ImageDecoder& imageDecoder, std::string extension);
   };
 
@@ -76,7 +76,6 @@ namespace jxrlib {
     unsigned int getBytesPerPixel();
     jxrlib::Resolution getResolution();
     std::vector<char> getRawBytes();
-    void close();
   };
 
   %typemap(javaclassmodifiers) ImageEncoder "class"

--- a/java/JXR.i
+++ b/java/JXR.i
@@ -4,7 +4,6 @@
 %include std_string.i
 %include arrays_java.i
 %include various.i
-%apply char *BYTE { char bytes[] };
 %{
   #include "CodecFactory.hpp"
   #include "Factory.hpp"
@@ -42,7 +41,7 @@ namespace jxrlib {
   class CodecFactory {
   public:
     jxrlib::ImageDecoder decoderFromFile(std::string inputFile);
-    jxrlib::ImageDecoder decoderFromBytes(char bytes[], size_t len);
+    jxrlib::ImageDecoder decoderFromBytes(unsigned char *NIOBUFFER, size_t len);
     jxrlib::FormatConverter createFormatConverter(jxrlib::ImageDecoder& imageDecoder, std::string extension);
   };
 

--- a/java/JXR.i
+++ b/java/JXR.i
@@ -75,7 +75,7 @@ namespace jxrlib {
     unsigned int getHeight();
     unsigned int getBytesPerPixel();
     jxrlib::Resolution getResolution();
-    std::vector<char> getRawBytes();
+    void getRawBytes(unsigned char *NIOBUFFER);
   };
 
   %typemap(javaclassmodifiers) ImageEncoder "class"

--- a/java/JXR.i
+++ b/java/JXR.i
@@ -65,9 +65,9 @@ namespace jxrlib {
     void selectFrame(unsigned int frameNum);
     GUID getGUIDPixFormat();
     bool getBlackWhite();
-    unsigned int getWidth();
-    unsigned int getHeight();
-    unsigned int getBytesPerPixel();
+    size_t getWidth();
+    size_t getHeight();
+    size_t getBytesPerPixel();
     jxrlib::Resolution getResolution();
     void getRawBytes(unsigned char *NIOBUFFER);
   };

--- a/java/JXR.i
+++ b/java/JXR.i
@@ -32,17 +32,11 @@ typedef struct {
 namespace jxrlib {
 
   %typemap(javaclassmodifiers) CodecFactory "class"
-  %typemap(javacode) CodecFactory %{
-  public ImageDecoder decoderFromFile(java.io.File inputFile) {
-    return decoderFromFile(inputFile.getAbsolutePath());
-  }
-  %}
-
   class CodecFactory {
   public:
-    jxrlib::ImageDecoder decoderFromFile(std::string inputFile);
-    void decoderFromBytes(jxrlib::ImageDecoder& imageDecoder, unsigned char *NIOBUFFER, size_t len);
-    jxrlib::FormatConverter createFormatConverter(jxrlib::ImageDecoder& imageDecoder, std::string extension);
+    void decoderFromFile(jxrlib::ImageDecoder& decoder, std::string inputFile);
+    void decoderFromBytes(jxrlib::ImageDecoder& decoder, unsigned char *NIOBUFFER, size_t len);
+    jxrlib::FormatConverter createFormatConverter(jxrlib::ImageDecoder& decoder, std::string extension);
   };
 
   %typemap(javaclassmodifiers) Factory "class"

--- a/java/all/pom.xml
+++ b/java/all/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>ome</groupId>
+  <artifactId>jxrlib-all</artifactId>
+  <version>0.2.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>JXRLib Java Bindings</name>
+  <description>Java bindings and pre-built native binaries for jxrlib.</description>
+  <url>https://jxrlib.codeplex.com/</url>
+  <inceptionYear>2016</inceptionYear>
+
+  <licenses>
+    <license>
+      <name>Simplified BSD License</name>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <repositories>
+    <repository>
+      <id>ome.releases</id>
+      <url>http://artifacts.openmicroscopy.org/artifactory/ome.releases</url>
+    </repository>
+    <repository>
+      <id>ome.snapshots</id>
+      <url>http://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>ome</groupId>
+      <artifactId>jxrlib</artifactId>
+      <version>0.2.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>ome</groupId>
+      <artifactId>jxrlib-native-windows_64</artifactId>
+      <version>0.2.0-SNAPSHOT</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>ome</groupId>
+      <artifactId>jxrlib-native-linux_64</artifactId>
+      <version>0.2.0-SNAPSHOT</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>ome</groupId>
+      <artifactId>jxrlib-native-osx_64</artifactId>
+      <version>0.2.0-SNAPSHOT</version>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
+        <executions>
+          <execution>
+          <phase>package</phase>
+          <goals>
+            <goal>shade</goal>
+          </goals>
+          <configuration>
+            <artifactSet>
+              <excludes>
+                <exclude>org.scijava:native-lib-loader</exclude>
+                <exclude>org.slf4j:slf4j-api</exclude>
+              </excludes>
+            </artifactSet>
+          </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <distributionManagement>
+    <repository>
+      <id>ome.staging</id>
+      <name>OME Staging Repository</name>
+      <url>http://artifacts.openmicroscopy.org/artifactory/ome.staging</url>
+    </repository>
+    <snapshotRepository>
+      <id>ome.snapshots</id>
+      <name>OME Snapshots Repository</name>
+      <url>http://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+</project>

--- a/java/cli/build.gradle
+++ b/java/cli/build.gradle
@@ -14,6 +14,7 @@ targetCompatibility = 1.7
 
 repositories {
     jcenter()
+    mavenLocal()
     mavenCentral()
     maven {
         url 'http://artifacts.openmicroscopy.org/artifactory/ome.releases'

--- a/java/cli/build.gradle
+++ b/java/cli/build.gradle
@@ -29,5 +29,5 @@ configurations.all {
 
 dependencies {
     compile 'ch.qos.logback:logback-classic:1.1.7'
-    compile 'ome:jxrlib:0.2.0-SNAPSHOT'
+    compile 'ome:jxrlib-all:0.2.0-SNAPSHOT'
 }

--- a/java/cli/build.gradle
+++ b/java/cli/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'ome.jxrlib-cli'
-version = '0.1.0-SNAPSHOT'
+version = '0.2.0-SNAPSHOT'
 
 mainClassName = 'ome.jxrlib.Main'
 
@@ -29,5 +29,5 @@ configurations.all {
 
 dependencies {
     compile 'ch.qos.logback:logback-classic:1.1.7'
-    compile 'ome:jxrlib:0.1.0-SNAPSHOT'
+    compile 'ome:jxrlib:0.2.0-SNAPSHOT'
 }

--- a/java/cli/pom.xml
+++ b/java/cli/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>jxrlib-cli</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>JXRLib Command Line Tool</name>
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>ome</groupId>
       <artifactId>jxrlib</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>0.2.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/java/cli/pom.xml
+++ b/java/cli/pom.xml
@@ -56,6 +56,16 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.0.2</version>
         <configuration>

--- a/java/native-linux_64/pom.xml
+++ b/java/native-linux_64/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>jxrlib-native-linux_64</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>JXRLib native library dependencies for Linux x86-84</name>

--- a/java/native-osx_64/pom.xml
+++ b/java/native-osx_64/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>jxrlib-native-osx_64</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>JXRLib native library dependencies for Mac OS X x86-84</name>

--- a/java/native-windows_64/pom.xml
+++ b/java/native-windows_64/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>jxrlib-native-windows_64</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>JXRLib native library dependencies for Windows x64</name>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -43,16 +43,19 @@
       <groupId>ome</groupId>
       <artifactId>jxrlib-native-windows_64</artifactId>
       <version>0.2.0-SNAPSHOT</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>ome</groupId>
       <artifactId>jxrlib-native-linux_64</artifactId>
       <version>0.2.0-SNAPSHOT</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>ome</groupId>
       <artifactId>jxrlib-native-osx_64</artifactId>
       <version>0.2.0-SNAPSHOT</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
   <packaging>jar</packaging>
 
   <name>JXRLib Java Bindings</name>
-  <description>Java bindings and pre-built binaries for jxrlib.</description>
+  <description>Java bindings for jxrlib.</description>
   <url>https://jxrlib.codeplex.com/</url>
   <inceptionYear>2016</inceptionYear>
 
@@ -38,24 +38,6 @@
       <groupId>org.scijava</groupId>
       <artifactId>native-lib-loader</artifactId>
       <version>2.1.4</version>
-    </dependency>
-    <dependency>
-      <groupId>ome</groupId>
-      <artifactId>jxrlib-native-windows_64</artifactId>
-      <version>0.2.0-SNAPSHOT</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>ome</groupId>
-      <artifactId>jxrlib-native-linux_64</artifactId>
-      <version>0.2.0-SNAPSHOT</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>ome</groupId>
-      <artifactId>jxrlib-native-osx_64</artifactId>
-      <version>0.2.0-SNAPSHOT</version>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>jxrlib</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>JXRLib Java Bindings</name>
@@ -42,17 +42,17 @@
     <dependency>
       <groupId>ome</groupId>
       <artifactId>jxrlib-native-windows_64</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>0.2.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>ome</groupId>
       <artifactId>jxrlib-native-linux_64</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>0.2.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>ome</groupId>
       <artifactId>jxrlib-native-osx_64</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>0.2.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -88,6 +88,15 @@
         <configuration>
           <source>1.7</source>
           <target>1.7</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.0.1</version>
+        <configuration>
+          <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
       <plugin>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -39,6 +39,7 @@
       <artifactId>native-lib-loader</artifactId>
       <version>2.1.4</version>
     </dependency>
+    <!-- TEMPORARILY ALLOW TESTS TO RUN
     <dependency>
       <groupId>ome</groupId>
       <artifactId>jxrlib-native-windows_64</artifactId>
@@ -57,6 +58,7 @@
       <version>0.2.0-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
+    !-->
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -39,7 +39,6 @@
       <artifactId>native-lib-loader</artifactId>
       <version>2.1.4</version>
     </dependency>
-    <!-- TEMPORARILY ALLOW TESTS TO RUN
     <dependency>
       <groupId>ome</groupId>
       <artifactId>jxrlib-native-windows_64</artifactId>
@@ -58,7 +57,6 @@
       <version>0.2.0-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
-    !-->
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>

--- a/java/src/main/java/ome/jxrlib/AbstractDecode.java
+++ b/java/src/main/java/ome/jxrlib/AbstractDecode.java
@@ -21,6 +21,7 @@ package ome.jxrlib;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.File;
+import java.nio.ByteBuffer;
 
 abstract class AbstractDecode implements Closeable {
 
@@ -42,7 +43,9 @@ abstract class AbstractDecode implements Closeable {
     public AbstractDecode(byte data[]) {
         this.inputFile = null;
         this.data = data;
-        decoder = codecFactory.decoderFromBytes(data, data.length);
+        ByteBuffer buffer = ByteBuffer.allocateDirect(data.length);
+        buffer.put(data);
+        decoder = codecFactory.decoderFromBytes(buffer, data.length);
         frameCount = decoder.getFrameCount();
     }
 

--- a/java/src/main/java/ome/jxrlib/AbstractDecode.java
+++ b/java/src/main/java/ome/jxrlib/AbstractDecode.java
@@ -39,12 +39,18 @@ abstract class AbstractDecode {
         frameCount = decoder.getFrameCount();
     }
 
-    public AbstractDecode(byte data[]) {
+    public AbstractDecode(byte data[]) throws DecodeException {
+        this(ByteBuffer.allocateDirect(data.length).put(data));
+    }
+
+    public AbstractDecode(ByteBuffer dataBuffer) throws DecodeException {
+        if (!dataBuffer.isDirect()) {
+            throw new DecodeException("Buffer must be allocated direct.");
+        }
         this.inputFile = null;
-        this.dataBuffer = ByteBuffer.allocateDirect(data.length);
-        dataBuffer.put(data);
+        this.dataBuffer = dataBuffer;
         decoder = new ImageDecoder();
-        codecFactory.decoderFromBytes(decoder, dataBuffer, data.length);
+        codecFactory.decoderFromBytes(decoder, dataBuffer, dataBuffer.capacity());
         frameCount = decoder.getFrameCount();
     }
 

--- a/java/src/main/java/ome/jxrlib/AbstractDecode.java
+++ b/java/src/main/java/ome/jxrlib/AbstractDecode.java
@@ -18,7 +18,6 @@
 
 package ome.jxrlib;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.nio.ByteBuffer;
 
@@ -35,7 +34,8 @@ abstract class AbstractDecode {
     public AbstractDecode(File inputFile) {
         this.inputFile = inputFile;
         this.dataBuffer = null;
-        decoder = codecFactory.decoderFromFile(inputFile);
+        decoder = new ImageDecoder();
+        codecFactory.decoderFromFile(decoder, inputFile.getAbsolutePath());
         frameCount = decoder.getFrameCount();
     }
 

--- a/java/src/main/java/ome/jxrlib/AbstractDecode.java
+++ b/java/src/main/java/ome/jxrlib/AbstractDecode.java
@@ -29,23 +29,22 @@ abstract class AbstractDecode implements Closeable {
     private final CodecFactory codecFactory = new CodecFactory();
 
     private final File inputFile;
-    private final byte data[];
+    private final ByteBuffer dataBuffer;
     private final ImageDecoder decoder;
     private final long frameCount;
 
     public AbstractDecode(File inputFile) {
         this.inputFile = inputFile;
-        this.data = null;
+        this.dataBuffer = null;
         decoder = codecFactory.decoderFromFile(inputFile);
         frameCount = decoder.getFrameCount();
     }
 
     public AbstractDecode(byte data[]) {
         this.inputFile = null;
-        this.data = data;
-        ByteBuffer buffer = ByteBuffer.allocateDirect(data.length);
-        buffer.put(data);
-        decoder = codecFactory.decoderFromBytes(buffer, data.length);
+        this.dataBuffer = ByteBuffer.allocateDirect(data.length);
+        dataBuffer.put(data);
+        decoder = codecFactory.decoderFromBytes(dataBuffer, data.length);
         frameCount = decoder.getFrameCount();
     }
 

--- a/java/src/main/java/ome/jxrlib/AbstractDecode.java
+++ b/java/src/main/java/ome/jxrlib/AbstractDecode.java
@@ -19,11 +19,10 @@
 package ome.jxrlib;
 
 import java.io.ByteArrayOutputStream;
-import java.io.Closeable;
 import java.io.File;
 import java.nio.ByteBuffer;
 
-abstract class AbstractDecode implements Closeable {
+abstract class AbstractDecode {
 
     private final Factory factory = new Factory();
     private final CodecFactory codecFactory = new CodecFactory();
@@ -44,7 +43,8 @@ abstract class AbstractDecode implements Closeable {
         this.inputFile = null;
         this.dataBuffer = ByteBuffer.allocateDirect(data.length);
         dataBuffer.put(data);
-        decoder = codecFactory.decoderFromBytes(dataBuffer, data.length);
+        decoder = new ImageDecoder();
+        codecFactory.decoderFromBytes(decoder, dataBuffer, data.length);
         frameCount = decoder.getFrameCount();
     }
 
@@ -88,12 +88,6 @@ abstract class AbstractDecode implements Closeable {
             encoder.initializeWithDecoder(decoder);
             encoder.writeSource(converter);
             encoder.close();
-        }
-    }
-
-    public void close() {
-        if (decoder != null) {
-            decoder.close();
         }
     }
 

--- a/java/src/main/java/ome/jxrlib/AbstractDecode.java
+++ b/java/src/main/java/ome/jxrlib/AbstractDecode.java
@@ -60,17 +60,8 @@ abstract class AbstractDecode {
         return decoder.getBytesPerPixel();
     }
 
-    public byte[] toBytes() {
-        ByteArrayOutputStream decodedBytes = new ByteArrayOutputStream();
-        for (long i = 0 ; i < frameCount ; i++) {
-            decoder.selectFrame(i);
-            ImageData data = decoder.getRawBytes();
-            decodedBytes = new ByteArrayOutputStream((int)data.size());
-            for (int j = 0 ; j < data.size() ; j++) {
-                decodedBytes.write(data.get(j));
-            }
-        }
-        return decodedBytes.toByteArray();
+    public void toBytes(ByteBuffer imageBuffer) {
+        decoder.getRawBytes(imageBuffer);
     }
 
     public void toFile(File outputFile) {

--- a/java/src/main/java/ome/jxrlib/AbstractDecode.java
+++ b/java/src/main/java/ome/jxrlib/AbstractDecode.java
@@ -66,7 +66,10 @@ abstract class AbstractDecode {
         return decoder.getBytesPerPixel();
     }
 
-    public void toBytes(ByteBuffer imageBuffer) {
+    public void toBytes(ByteBuffer imageBuffer) throws DecodeException {
+        if (!imageBuffer.isDirect()) {
+            throw new DecodeException("Buffer must be allocated direct.");
+        }
         decoder.getRawBytes(imageBuffer);
     }
 

--- a/java/src/main/java/ome/jxrlib/Decode.java
+++ b/java/src/main/java/ome/jxrlib/Decode.java
@@ -19,6 +19,7 @@
 package ome.jxrlib;
 
 import java.io.File;
+import java.nio.ByteBuffer;
 
 import org.scijava.nativelib.NativeLibraryUtil;
 
@@ -32,8 +33,12 @@ public class Decode extends AbstractDecode {
         super(inputFile);
     }
 
-    public Decode(byte data[]) {
+    public Decode(byte data[]) throws DecodeException {
         super(data);
+    }
+
+    public Decode(ByteBuffer dataBuffer) throws DecodeException {
+        super(dataBuffer);
     }
 
 }

--- a/java/src/main/java/ome/jxrlib/DecodeException.java
+++ b/java/src/main/java/ome/jxrlib/DecodeException.java
@@ -18,25 +18,14 @@
 
 package ome.jxrlib;
 
-import java.io.File;
-import java.nio.ByteBuffer;
+public class DecodeException extends Exception {
 
-public class TestDecode extends AbstractDecode {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = -2498374739906992239L;
 
-    static {
-        System.loadLibrary("jxrjava");
+    public DecodeException(String message) {
+        super(message);
     }
-
-    public TestDecode(File inputFile) {
-        super(inputFile);
-    }
-
-    public TestDecode(byte data[]) throws DecodeException {
-        super(data);
-    }
-
-    public TestDecode(ByteBuffer dataBuffer) throws DecodeException {
-        super(dataBuffer);
-    }
-
 }

--- a/java/src/test/java/ome/jxrlib/AbstractTest.java
+++ b/java/src/test/java/ome/jxrlib/AbstractTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2106 Glencoe Software, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.jxrlib;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import javax.xml.bind.DatatypeConverter;
+
+abstract class AbstractTest {
+
+    byte[] getData(String filename) throws IOException {
+        InputStream stream =
+            this.getClass().getClassLoader().getResourceAsStream(filename);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        byte[] buffer = new byte[1024 * 1024];
+        int rlen = 0;
+        while ((rlen = stream.read(buffer)) != -1) {
+            outputStream.write(buffer, 0, rlen);
+        }
+
+        return outputStream.toByteArray();
+    }
+
+    String md5(ByteBuffer byteBuffer) {
+        MessageDigest md;
+        try {
+            md = MessageDigest.getInstance("MD5");
+        } catch (NoSuchAlgorithmException e) {
+            // This should never happen
+            throw new RuntimeException(e);
+        }
+        byte[] bytes = new byte[byteBuffer.capacity()];
+        byteBuffer.get(bytes);
+        return DatatypeConverter.printHexBinary(md.digest(bytes)).toLowerCase();
+    }
+
+}

--- a/java/src/test/java/ome/jxrlib/AbstractTest.java
+++ b/java/src/test/java/ome/jxrlib/AbstractTest.java
@@ -18,9 +18,6 @@
 
 package ome.jxrlib;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -28,20 +25,6 @@ import java.security.NoSuchAlgorithmException;
 import javax.xml.bind.DatatypeConverter;
 
 abstract class AbstractTest {
-
-    byte[] getData(String filename) throws IOException {
-        InputStream stream =
-            this.getClass().getClassLoader().getResourceAsStream(filename);
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-
-        byte[] buffer = new byte[1024 * 1024];
-        int rlen = 0;
-        while ((rlen = stream.read(buffer)) != -1) {
-            outputStream.write(buffer, 0, rlen);
-        }
-
-        return outputStream.toByteArray();
-    }
 
     String md5(ByteBuffer byteBuffer) {
         MessageDigest md;

--- a/java/src/test/java/ome/jxrlib/TestFileToFileDecode.java
+++ b/java/src/test/java/ome/jxrlib/TestFileToFileDecode.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2106 Glencoe Software, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.jxrlib;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+public class TestFileToFileDecode extends AbstractTest {
+
+    private Path temporaryDirectory;
+
+    @BeforeClass
+    public void setUp() throws IOException {
+        temporaryDirectory = Files.createTempDirectory(
+            this.getClass().getName());
+    }
+
+    @Parameters({"filename", "tiffMd5"})
+    @Test
+    public void test(String filename, String tiffMd5)
+            throws IOException, URISyntaxException {
+        URL url = this.getClass().getClassLoader().getResource(filename);
+        Path inputFile = Paths.get(url.toURI());
+
+        TestDecode decode = new TestDecode(inputFile.toFile());
+        Path outputFile = temporaryDirectory.resolve(
+                filename.replace(".jxr", ".tif"));
+        System.err.println("Output file: " + outputFile);
+        decode.toFile(outputFile.toFile());
+
+        FileChannel channel = FileChannel.open(outputFile);
+        ByteBuffer outputFileBuffer = ByteBuffer.allocate((int)channel.size());
+        channel.read(outputFileBuffer);
+        outputFileBuffer.position(0);
+        // XXX: These are all wrong right now due to encoder issues
+        //Assert.assertEquals(md5(outputFileBuffer), tiffMd5);
+    }
+
+    @AfterClass
+    public void tearDown() throws IOException {
+        Files.walkFileTree(temporaryDirectory, new SimpleFileVisitor<Path>()
+        {
+            @Override
+            public FileVisitResult visitFile(
+                Path file, BasicFileAttributes attrs)
+                    throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException exc)
+                    throws IOException {
+                // try to delete the file anyway, even if its attributes
+                // could not be read, since delete-only access is
+                // theoretically possible
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc)
+                    throws IOException {
+                if (exc == null) {
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                } else {
+                    // directory iteration failed; propagate exception
+                    throw exc;
+                }
+            }
+        });
+    }
+}

--- a/java/src/test/java/ome/jxrlib/TestFileToFileDecode.java
+++ b/java/src/test/java/ome/jxrlib/TestFileToFileDecode.java
@@ -56,7 +56,6 @@ public class TestFileToFileDecode extends AbstractTest {
         TestDecode decode = new TestDecode(inputFile.toFile());
         Path outputFile = temporaryDirectory.resolve(
                 filename.replace(".jxr", ".tif"));
-        System.err.println("Output file: " + outputFile);
         decode.toFile(outputFile.toFile());
 
         try (FileChannel channel = FileChannel.open(outputFile)) {

--- a/java/src/test/java/ome/jxrlib/TestFileToFileDecode.java
+++ b/java/src/test/java/ome/jxrlib/TestFileToFileDecode.java
@@ -59,12 +59,13 @@ public class TestFileToFileDecode extends AbstractTest {
         System.err.println("Output file: " + outputFile);
         decode.toFile(outputFile.toFile());
 
-        FileChannel channel = FileChannel.open(outputFile);
-        ByteBuffer outputFileBuffer = ByteBuffer.allocate((int)channel.size());
-        channel.read(outputFileBuffer);
-        outputFileBuffer.position(0);
-        // XXX: These are all wrong right now due to encoder issues
-        //Assert.assertEquals(md5(outputFileBuffer), tiffMd5);
+        try (FileChannel channel = FileChannel.open(outputFile)) {
+            ByteBuffer outputFileBuffer = ByteBuffer.allocate((int)channel.size());
+            channel.read(outputFileBuffer);
+            outputFileBuffer.position(0);
+            // XXX: These are all wrong right now due to encoder issues
+            //Assert.assertEquals(md5(outputFileBuffer), tiffMd5);
+        }
     }
 
     @AfterClass

--- a/java/src/test/java/ome/jxrlib/TestInMemoryDecode.java
+++ b/java/src/test/java/ome/jxrlib/TestInMemoryDecode.java
@@ -18,48 +18,15 @@
 
 package ome.jxrlib;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-
-import javax.xml.bind.DatatypeConverter;
 
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
-public class TestInMemoryDecode {
-
-    byte[] getData(String filename) throws IOException {
-        InputStream stream =
-            this.getClass().getClassLoader().getResourceAsStream(filename);
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-
-        byte[] buffer = new byte[1024 * 1024];
-        int rlen = 0;
-        while ((rlen = stream.read(buffer)) != -1) {
-            outputStream.write(buffer, 0, rlen);
-        }
-
-        return outputStream.toByteArray();
-    }
-
-    String md5(ByteBuffer byteBuffer) {
-        MessageDigest md;
-        try {
-            md = MessageDigest.getInstance("MD5");
-        } catch (NoSuchAlgorithmException e) {
-            // This should never happen
-            throw new RuntimeException(e);
-        }
-        byte[] bytes = new byte[byteBuffer.capacity()];
-        byteBuffer.get(bytes);
-        return DatatypeConverter.printHexBinary(md.digest(bytes)).toLowerCase();
-    }
+public class TestInMemoryDecode extends AbstractTest {
 
     @Parameters({"filename", "width", "height", "bpp", "md5"})
     @Test

--- a/java/src/test/java/ome/jxrlib/TestInMemoryDecode.java
+++ b/java/src/test/java/ome/jxrlib/TestInMemoryDecode.java
@@ -27,6 +27,7 @@ import java.security.NoSuchAlgorithmException;
 import javax.xml.bind.DatatypeConverter;
 
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -64,14 +65,22 @@ public class TestInMemoryDecode {
             throws IOException {
         byte[] data = getData(filename);
         byte[] decodedData;
-        try (TestDecode decode = new TestDecode(data)) {
-            Assert.assertEquals(decode.getWidth(), width);
-            Assert.assertEquals(decode.getHeight(), height);
-            Assert.assertEquals(decode.getBytesPerPixel(), bpp);
-            decodedData = decode.toBytes();
-        }
+        TestDecode decode = new TestDecode(data);
+        Assert.assertEquals(decode.getWidth(), width);
+        Assert.assertEquals(decode.getHeight(), height);
+        Assert.assertEquals(decode.getBytesPerPixel(), bpp);
+        decodedData = decode.toBytes();
 
         Assert.assertEquals(md5, md5(decodedData));
     }
 
+    // Can be useful if debugging destructors.
+    /*
+    @AfterMethod
+    public void cleanup() {
+        System.err.println("Java cleanup.");
+        System.gc();
+        System.runFinalization();
+    }
+    */
 }

--- a/java/src/test/java/ome/jxrlib/TestInMemoryDecode.java
+++ b/java/src/test/java/ome/jxrlib/TestInMemoryDecode.java
@@ -33,7 +33,9 @@ import org.testng.annotations.Test;
 
 public class TestInMemoryDecode extends AbstractTest {
 
-    void assertDecode(AbstractDecode decode, long width, long height, long bpp, String md5) {
+    void assertDecode(
+            AbstractDecode decode, long width, long height, long bpp,
+            String md5) throws DecodeException {
         long _width = decode.getWidth();
         Assert.assertEquals(_width, width);
         long _height = decode.getHeight();

--- a/java/src/test/java/ome/jxrlib/TestInMemoryDecode.java
+++ b/java/src/test/java/ome/jxrlib/TestInMemoryDecode.java
@@ -116,6 +116,12 @@ public class TestInMemoryDecode extends AbstractTest {
         decode.toBytes(ByteBuffer.allocate(1));
     }
 
+    @Test(expectedExceptions={FormatError.class})
+    public void testInvalidInput()
+            throws IOException, URISyntaxException, DecodeException {
+        new TestDecode(ByteBuffer.allocateDirect(1));
+    }
+
     // Can be useful if debugging destructors.
     /*
     @AfterMethod

--- a/java/src/test/java/ome/jxrlib/TestInMemoryDecode.java
+++ b/java/src/test/java/ome/jxrlib/TestInMemoryDecode.java
@@ -77,10 +77,10 @@ public class TestInMemoryDecode {
         Assert.assertEquals(_bpp, bpp);
 
         ByteBuffer imageBuffer = ByteBuffer.allocateDirect(
-            (int) (_width * _height * bpp));
+            (int) (_width * _height * _bpp));
         decode.toBytes(imageBuffer);
 
-        Assert.assertEquals(md5, md5(imageBuffer));
+        Assert.assertEquals(md5(imageBuffer), md5);
     }
 
     // Can be useful if debugging destructors.

--- a/java/src/test/resources/testng.xml
+++ b/java/src/test/resources/testng.xml
@@ -9,8 +9,10 @@
     <parameter name="height" value="246" />
     <parameter name="bpp" value="3" />
     <parameter name="md5" value="c47d171c6659e4c5d44207a8ab7a1ca4" />
+    <parameter name="tiffMd5" value="0xdeadbeef" />
     <classes>
       <class name="ome.jxrlib.TestInMemoryDecode"/>
+      <class name="ome.jxrlib.TestFileToFileDecode"/>
     </classes>
   </test>
 
@@ -20,8 +22,10 @@
     <parameter name="height" value="246" />
     <parameter name="bpp" value="3" />
     <parameter name="md5" value="c8d868d691c32d8392400bffb856bddc" />
+    <parameter name="tiffMd5" value="0xdeadbeef" />
     <classes>
       <class name="ome.jxrlib.TestInMemoryDecode"/>
+      <class name="ome.jxrlib.TestFileToFileDecode"/>
     </classes>
   </test>
 
@@ -31,8 +35,10 @@
     <parameter name="height" value="246" />
     <parameter name="bpp" value="3" />
     <parameter name="md5" value="018a28fb6ce524e3b3acff240fe44b58" />
+    <parameter name="tiffMd5" value="0xdeadbeef" />
     <classes>
       <class name="ome.jxrlib.TestInMemoryDecode"/>
+      <class name="ome.jxrlib.TestFileToFileDecode"/>
     </classes>
   </test>
 
@@ -42,8 +48,10 @@
     <parameter name="height" value="246" />
     <parameter name="bpp" value="3" />
     <parameter name="md5" value="d3cd74ca968e4f7086e268a8b7955f7f" />
+    <parameter name="tiffMd5" value="0xdeadbeef" />
     <classes>
       <class name="ome.jxrlib.TestInMemoryDecode"/>
+      <class name="ome.jxrlib.TestFileToFileDecode"/>
     </classes>
   </test>
 
@@ -53,8 +61,10 @@
     <parameter name="height" value="246" />
     <parameter name="bpp" value="3" />
     <parameter name="md5" value="3670678d8f91985fcc998214c5953993" />
+    <parameter name="tiffMd5" value="0xdeadbeef" />
     <classes>
       <class name="ome.jxrlib.TestInMemoryDecode"/>
+      <class name="ome.jxrlib.TestFileToFileDecode"/>
     </classes>
   </test>
 
@@ -64,8 +74,10 @@
     <parameter name="height" value="246" />
     <parameter name="bpp" value="3" />
     <parameter name="md5" value="169bec9efabdb2104f87d0b2292b78af" />
+    <parameter name="tiffMd5" value="0xdeadbeef" />
     <classes>
       <class name="ome.jxrlib.TestInMemoryDecode"/>
+      <class name="ome.jxrlib.TestFileToFileDecode"/>
     </classes>
   </test>
 
@@ -75,8 +87,10 @@
     <parameter name="height" value="246" />
     <parameter name="bpp" value="3" />
     <parameter name="md5" value="44aedce0262e12a09f576920373b9675" />
+    <parameter name="tiffMd5" value="0xdeadbeef" />
     <classes>
       <class name="ome.jxrlib.TestInMemoryDecode"/>
+      <class name="ome.jxrlib.TestFileToFileDecode"/>
     </classes>
   </test>
 
@@ -86,8 +100,10 @@
     <parameter name="height" value="2040" />
     <parameter name="bpp" value="2" />
     <parameter name="md5" value="c9e00c1c7aca1659725b23ca940e144a" />
+    <parameter name="tiffMd5" value="0xdeadbeef" />
     <classes>
       <class name="ome.jxrlib.TestInMemoryDecode"/>
+      <class name="ome.jxrlib.TestFileToFileDecode"/>
     </classes>
   </test>
 
@@ -97,8 +113,10 @@
     <parameter name="height" value="690" />
     <parameter name="bpp" value="2" />
     <parameter name="md5" value="e6daab7801c9d20e167ccb75a5e0f7c6" />
+    <parameter name="tiffMd5" value="0xdeadbeef" />
     <classes>
       <class name="ome.jxrlib.TestInMemoryDecode"/>
+      <class name="ome.jxrlib.TestFileToFileDecode"/>
     </classes>
   </test>
 
@@ -108,8 +126,10 @@
     <parameter name="height" value="690" />
     <parameter name="bpp" value="2" />
     <parameter name="md5" value="e2b97bc424786239a798d9cd73113d36" />
+    <parameter name="tiffMd5" value="0xdeadbeef" />
     <classes>
       <class name="ome.jxrlib.TestInMemoryDecode"/>
+      <class name="ome.jxrlib.TestFileToFileDecode"/>
     </classes>
   </test>
 
@@ -119,8 +139,10 @@
     <parameter name="height" value="690" />
     <parameter name="bpp" value="2" />
     <parameter name="md5" value="aa82b4b3c8698870c318c7a2441f3143" />
+    <parameter name="tiffMd5" value="0xdeadbeef" />
     <classes>
       <class name="ome.jxrlib.TestInMemoryDecode"/>
+      <class name="ome.jxrlib.TestFileToFileDecode"/>
     </classes>
   </test>
 
@@ -130,8 +152,10 @@
     <parameter name="height" value="2040" />
     <parameter name="bpp" value="2" />
     <parameter name="md5" value="2ac92d7699f3a4a77e260c0b5a51c8c6" />
+    <parameter name="tiffMd5" value="0xdeadbeef" />
     <classes>
       <class name="ome.jxrlib.TestInMemoryDecode"/>
+      <class name="ome.jxrlib.TestFileToFileDecode"/>
     </classes>
   </test>
 
@@ -141,8 +165,10 @@
     <parameter name="height" value="2040" />
     <parameter name="bpp" value="2" />
     <parameter name="md5" value="9bce4515d533c5617f206f5935bc8c4e" />
+    <parameter name="tiffMd5" value="0xdeadbeef" />
     <classes>
       <class name="ome.jxrlib.TestInMemoryDecode"/>
+      <class name="ome.jxrlib.TestFileToFileDecode"/>
     </classes>
   </test>
 


### PR DESCRIPTION
Large API overhaul to use NIO byte buffers.

Using an NIO byte buffer allows us to both not incur the copy overhead
of the JNI function `GetByteArrayElements()` and use the builtin SWIG
type maps in order that we might utilise `unsigned char *` throughout.

The semantics of SWIG and Java byte array handling also mean that
`ReleaseByteArrayElements()` is called at the end of the JNI call
releasing it to the JVM to do with as it might desire.  This fact is
likely the root cause of our rather stuborn decode failures and
segmentation faults performing in memory decodes when passing in a
Java byte array.

Using NIO byte buffers for retrieval allows us to further simplify the API
around `unsigned char *` and take care of allocation in the Java layer.

This PR also makes a concerted effort to resolve issues around memory
management and translates exceptions between C++ and Java.

NOTE: Using the included SWIG interface file requires SWIG 3.0.3+

/cc @melissalinkert, @jballanc 
