### PR TITLE
CentOS 6 (GLIBC 2.12) support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,29 +45,41 @@ script:
 # Set up our Maven and SWIG environment
   - mkdir -p $HOME/.m2
   - cat java/settings.xml | sed s/__MAVEN_SERVER_USERNAME__/$MAVEN_SERVER_USERNAME/g | sed s/__MAVEN_SERVER_PASSWORD__/$MAVEN_SERVER_PASSWORD/g > $HOME/.m2/settings.xml
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export SWIG=$HOME/swig/bin/swig ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      export SWIG=$HOME/swig/bin/swig;
+      export LD_LIBRARY_PATH="$TRAVIS_BUILD_DIR/build";
+    else
+      export DYLD_LIBRARY_PATH="$TRAVIS_BUILD_DIR/build";
+    fi
 # Build native code
   - make clean swig all
 # Prepare to run tests
   - cd build
   - mkdir -p transcoded/C/ transcoded/C++/ transcoded/Java/
 # Test base jxrlib C library
-  - for input in ../fixtures/first-tiles/*; do bn=${input##*/} ; bn=${bn%.jxr} ; ./JxrDecApp -i "$input" -o "transcoded/C/$bn.tif" ; done
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=`pwd` ; else export LD_LIBRARY_PATH=`pwd` ; fi
-# Test jxrlib C++ wrapper library (file to file)
-  - for input in ../fixtures/first-tiles/*; do bn=${input##*/} ; bn=${bn%.jxr} ; ./jxrdecode "$input" "transcoded/C++/$bn.tif" ; done
-# Test jxrlib C++ wrapper library (in memory)
-  - for input in ../fixtures/first-tiles/*; do ./jxrdecode --in-memory "$input" &> /dev/null ; done
+  - for input in ../fixtures/first-tiles/*; do
+      basename=${input##*/};
+      basename=${bn%.jxr};
+      ./JxrDecApp -i "$input" -o "transcoded/C/$basename.tif";
+      ./jxrdecode "$input" "transcoded/C++/$basename.tif";
+      ./jxrdecode --in-memory "$input" &> /dev/null;
+    done
 # Test jxrlib Java bindings (in memory and file to file)
+  - mvn -f ../java/pom.xml test
+# Testing was successful
   - cd $TRAVIS_BUILD_DIR
-  - mvn -f java/pom.xml test
-# Testing was successful, deploy the clang environment artifacts when on Linux and we're not building a PR
-  - if [[ "$CXX" == "clang++" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then mvn -f java/pom.xml deploy; fi
-# Package and deploy
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd java/native-osx_64 ; else cd java/native-linux_64 ; fi
-  - mvn package
-# Only deploy the clang compiled artifacts when we're not building a PR
-  - if [[ "$CXX" == "clang++" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then mvn deploy ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      mvn -f java/native-linux_64 package;
+      if [[ "$TRAVIS_PULL_REQUEST" == "false" ]] && [[ "$CC" == "gcc" ]]; then
+        mvn -f java/native-linux_64 deploy;
+        mvn -f java/pom.xml deploy;
+      fi
+    else
+      mvn -f java/native-osx_64 package;
+      if [[ "$TRAVIS_PULL_REQUEST" == "false" ]] && [[ "$CC" == "clang" ]]; then
+        mvn -f java/native-osx_64 deploy;
+      fi
+    fi
 
 cache:
   directories:

--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,8 @@ endif
 
 CD=cd
 MK_DIR=mkdir -p
-CFLAGS=-I. -Icommon/include -I$(DIR_SYS) $(ENDIANFLAG) -D__ANSI__ -DDISABLE_PERF_MEASUREMENT -w -fPIC
-CXXFLAGS=-I. -Icommon/include -I$(DIR_SYS) -I$(DIR_GLUE) -I$(DIR_TEST) -Wno-self-assign-field -Wno-unsequenced -fPIC
+CFLAGS=-I. -Icommon/include -I$(DIR_SYS) $(ENDIANFLAG) -D__ANSI__ -DDISABLE_PERF_MEASUREMENT -w -Os -fPIC
+CXXFLAGS=-I. -Icommon/include -I$(DIR_SYS) -I$(DIR_GLUE) -I$(DIR_TEST) -Wno-self-assign-field -Wno-unsequenced -Os -fPIC
 
 ifdef DEBUG
 CFLAGS:=$(CFLAGS) -g -O0 -DDEBUG

--- a/image/decode/JXRTranscode.c
+++ b/image/decode/JXRTranscode.c
@@ -206,7 +206,7 @@ Void transformDCBlock(PixelI * pOrg, PixelI * pDst, ORIENTATION oOrientation)
             pOrg[i + 4] = -pOrg[i + 4], pOrg[i + 12] = -pOrg[i + 12];
 
     if(oOrientation < O_RCW)
-        memcpy(pDst, pOrg, 16 * sizeof(PixelI));
+        memmove(pDst, pOrg, 16 * sizeof(PixelI));
     else
         for(i = 0; i < 16; i ++)
             pDst[i] = pOrg[(i >> 2) + ((i & 3) << 2)];
@@ -225,7 +225,7 @@ Void transformDCBlock422(PixelI * pOrg, PixelI * pDst, ORIENTATION oOrientation)
     if(bFlipV[oOrientation])
         pDst[0] = pOrg[0], pDst[1] = pOrg[5], pDst[2] = pOrg[6], pDst[3] = pOrg[7], pDst[4] = pOrg[4], pDst[5] = pOrg[1], pDst[6] = pOrg[2], pDst[7] = pOrg[3];
     else
-        memcpy(pDst, pOrg, 8 * sizeof(PixelI));
+        memmove(pDst, pOrg, 8 * sizeof(PixelI));
 }
 
 Void transformDCBlock420(PixelI * pOrg, PixelI * pDst, ORIENTATION oOrientation)
@@ -265,7 +265,7 @@ Void transformACBlocks(PixelI * pOrg, PixelI * pDst, ORIENTATION oOrientation)
             size_t jj = (bFlipH[oOrientation] ? 3 - j : j);
 
             if(oOrientation < O_RCW)
-                memcpy(pDst + (jj * 4 + ii) * 16, pOrg + (j * 4 + i) * 16, 16 * sizeof(PixelI));
+                memmove(pDst + (jj * 4 + ii) * 16, pOrg + (j * 4 + i) * 16, 16 * sizeof(PixelI));
             else{
                 pO = pOrg + (j * 4 + i) * 16;
                 pD = pDst + (ii * 4 + jj) * 16;
@@ -298,7 +298,7 @@ Void transformACBlocks422(PixelI * pOrg, PixelI * pDst, ORIENTATION oOrientation
             size_t ii = (bFlipV[oOrientation] ? 3 - i : i);
             size_t jj = (bFlipH[oOrientation] ? 1 - j : j);
 
-            memcpy(pDst + (jj * 4 + ii) * 16, pOrg + (j * 4 + i) * 16, 16 * sizeof(PixelI));
+            memmove(pDst + (jj * 4 + ii) * 16, pOrg + (j * 4 + i) * 16, 16 * sizeof(PixelI));
         }
 }
 
@@ -324,7 +324,7 @@ Void transformACBlocks420(PixelI * pOrg, PixelI * pDst, ORIENTATION oOrientation
             size_t jj = (bFlipH[oOrientation] ? 1 - j : j);
 
             if(oOrientation < O_RCW)
-                memcpy(pDst + (jj * 2 + ii) * 16, pOrg + (j * 2 + i) * 16, 16 * sizeof(PixelI));
+                memmove(pDst + (jj * 2 + ii) * 16, pOrg + (j * 2 + i) * 16, 16 * sizeof(PixelI));
             else{
                 pO = pOrg + (j * 2 + i) * 16;
                 pD = pDst + (ii * 2 + jj) * 16;
@@ -887,12 +887,12 @@ Int WMPhotoTranscode(struct WMPStream * pStreamIn, struct WMPStream * pStreamOut
 
                     pMBInfo[cOff] = pSCDec->MBInfo;
 
-                    memcpy(&pFrameBuf[cOff * cUnit], pMBBuf, cUnit * sizeof(PixelI));
+                    memmove(&pFrameBuf[cOff * cUnit], pMBBuf, cUnit * sizeof(PixelI));
 
                     if(pParam->uAlphaMode > 0){
                         pMBInfoAlpha[cOff] = pSCDec->m_pNextSC->MBInfo;
                         
-                        memcpy(&pFrameBufAlpha[cOff * 256], MBBufAlpha, 256 * sizeof(PixelI));
+                        memmove(&pFrameBufAlpha[cOff * 256], MBBufAlpha, 256 * sizeof(PixelI));
                     }
                 }
             }

--- a/image/decode/strdec.c
+++ b/image/decode/strdec.c
@@ -3185,7 +3185,7 @@ static Void InitializeStrDec(CWMImageStrCodec *pSC,
   const CCoreParameters *pParams, const CWMImageStrCodec *pSCIn)
 {
     // copy core parameters
-    memcpy (&(pSC->m_param), pParams, sizeof (CCoreParameters));
+    memmove (&(pSC->m_param), pParams, sizeof (CCoreParameters));
 
     pSC->cbStruct = sizeof(*pSC);
     pSC->WMII = pSCIn->WMII;

--- a/image/sys/strcodec.c
+++ b/image/sys/strcodec.c
@@ -177,8 +177,8 @@ Void initMRPtr(CWMImageStrCodec* pSC)
     size_t j, jend = (pSC->m_pNextSC != NULL);
 
     for (j = 0; j <= jend; j++) {
-        memcpy (pSC->p0MBbuffer, pSC->a0MBbuffer, sizeof (pSC->p0MBbuffer));
-        memcpy (pSC->p1MBbuffer, pSC->a1MBbuffer, sizeof (pSC->p1MBbuffer));
+        memmove (pSC->p0MBbuffer, pSC->a0MBbuffer, sizeof (pSC->p0MBbuffer));
+        memmove (pSC->p1MBbuffer, pSC->a1MBbuffer, sizeof (pSC->p1MBbuffer));
         pSC = pSC->m_pNextSC;
     }
 }
@@ -226,9 +226,9 @@ Void swapMRPtr(CWMImageStrCodec* pSC)
     size_t j, jend = (pSC->m_pNextSC != NULL);
 
     for (j = 0; j <= jend; j++) {
-        memcpy (pTemp, pSC->a0MBbuffer, sizeof (pSC->a0MBbuffer));
-        memcpy (pSC->a0MBbuffer, pSC->a1MBbuffer, sizeof (pSC->a0MBbuffer));
-        memcpy (pSC->a1MBbuffer, pTemp, sizeof (pSC->a0MBbuffer));
+        memmove (pTemp, pSC->a0MBbuffer, sizeof (pSC->a0MBbuffer));
+        memmove (pSC->a0MBbuffer, pSC->a1MBbuffer, sizeof (pSC->a0MBbuffer));
+        memmove (pSC->a1MBbuffer, pTemp, sizeof (pSC->a0MBbuffer));
         pSC = pSC->m_pNextSC;
     }
 }
@@ -406,7 +406,7 @@ ERR ReadWS_Memory(struct WMPStream* pWS, void* pv, size_t cb)
         cb = pWS->state.buf.cbBuf - pWS->state.buf.cbCur;
     }
 
-    memcpy(pv, pWS->state.buf.pbBuf + pWS->state.buf.cbCur, cb);
+    memmove(pv, pWS->state.buf.pbBuf + pWS->state.buf.cbCur, cb);
     pWS->state.buf.cbCur += cb;
 
 Cleanup:
@@ -420,7 +420,7 @@ ERR WriteWS_Memory(struct WMPStream* pWS, const void* pv, size_t cb)
     FailIf(pWS->state.buf.cbCur + cb < pWS->state.buf.cbCur, WMP_errBufferOverflow);
     FailIf(pWS->state.buf.cbBuf < pWS->state.buf.cbCur + cb, WMP_errBufferOverflow);
 
-    memcpy(pWS->state.buf.pbBuf + pWS->state.buf.cbCur, pv, cb);
+    memmove(pWS->state.buf.pbBuf + pWS->state.buf.cbCur, pv, cb);
     pWS->state.buf.cbCur += cb;
 
 Cleanup:
@@ -517,7 +517,7 @@ ERR ReadWS_List(struct WMPStream* pWS, void* pv, size_t cb)
         size_t cl = PACKETLENGTH - pWS->state.buf.cbCur;
         if (cl > cb)
             cl = cb;
-        memcpy(pv, pWS->state.buf.pbBuf + pWS->state.buf.cbCur, cl);
+        memmove(pv, pWS->state.buf.pbBuf + pWS->state.buf.cbCur, cl);
         pWS->state.buf.cbCur += cl;
         pv = (void *)((U8 *)pv + cl);
         cb -= cl;
@@ -545,7 +545,7 @@ ERR WriteWS_List(struct WMPStream* pWS, const void* pv, size_t cb)
         size_t cl = PACKETLENGTH - pWS->state.buf.cbCur;
         if (cl > cb)
             cl = cb;
-        memcpy(pWS->state.buf.pbBuf + pWS->state.buf.cbCur, pv, cl);
+        memmove(pWS->state.buf.pbBuf + pWS->state.buf.cbCur, pv, cl);
         pWS->state.buf.cbCur += cl;
         pv = (const void *)((U8 *)pv + cl);
         cb -= cl;

--- a/jxrgluelib/JXRGlueJxr.c
+++ b/jxrgluelib/JXRGlueJxr.c
@@ -143,14 +143,14 @@ ERR CopyDescMetadata(DPKPROPVARIANT *pvarDst,
             pvarDst->vt = DPKVT_LPSTR;
             uiSize = strlen(varSrc.VT.pszVal) + 1;
             Call(PKAlloc((void **) &pvarDst->VT.pszVal, uiSize));
-            memcpy(pvarDst->VT.pszVal, varSrc.VT.pszVal, uiSize);
+            memmove(pvarDst->VT.pszVal, varSrc.VT.pszVal, uiSize);
             break;
             
         case DPKVT_LPWSTR:
             pvarDst->vt = DPKVT_LPWSTR;
             uiSize = sizeof(U16) * (wcslen((wchar_t *) varSrc.VT.pwszVal) + 1); // +1 for NULL term
             Call(PKAlloc((void **) &pvarDst->VT.pszVal, uiSize));
-            memcpy(pvarDst->VT.pwszVal, varSrc.VT.pwszVal, uiSize);
+            memmove(pvarDst->VT.pwszVal, varSrc.VT.pwszVal, uiSize);
             break;
 
         case DPKVT_UI2:
@@ -1025,7 +1025,7 @@ static ERR SetMetadata(PKImageEncode *pIE, const U8 *pbMetadata, U32 cbMetadata,
     *pcbSet = 0;
 
     Call(PKAlloc((void **) pbSet, cbMetadata));
-    memcpy(*pbSet, pbMetadata, cbMetadata);
+    memmove(*pbSet, pbMetadata, cbMetadata);
     *pcbSet = cbMetadata;
 
 Cleanup:
@@ -1065,7 +1065,7 @@ ERR PKImageEncode_SetXMPMetadata_WMP(PKImageEncode *pIE, const U8 *pbXMPMetadata
     // but anyway this block will be large enough guaranteed
     cbBuffer = cbXMPMetadata + 1 + sizeof("<dc:format>") - 1 + sizeof("</dc:format>") - 1 + sizeof(szHDPhotoFormat) - 1;
     Call(PKAlloc((void **) &pbTemp, cbBuffer));
-    memcpy(pbTemp, pbXMPMetadata, cbXMPMetadata); // Make a copy of the metadata
+    memmove(pbTemp, pbXMPMetadata, cbXMPMetadata); // Make a copy of the metadata
     pbTemp[cbXMPMetadata] = '\0';
     cbXMPMetadata = (U32)strlen(pbTemp);
     pszFormatBegin = strstr(pbTemp, "<dc:format>");
@@ -1088,7 +1088,7 @@ ERR PKImageEncode_SetXMPMetadata_WMP(PKImageEncode *pIE, const U8 *pbXMPMetadata
             cbBuffer - (pszFormatBegin - pbTemp),
             szHDPhotoFormat),
             WMP_errBufferOverflow);
-        memcpy(pszFormatBegin + sizeof(szHDPhotoFormat) - 1, pbXMPMetadata + ( pszFormatEnd - pbTemp ),
+        memmove(pszFormatBegin + sizeof(szHDPhotoFormat) - 1, pbXMPMetadata + ( pszFormatEnd - pbTemp ),
             cbXMPMetadata - ( pszFormatEnd - pbTemp ));
     }
     else

--- a/jxrgluelib/JXRMeta.c
+++ b/jxrgluelib/JXRMeta.c
@@ -39,7 +39,7 @@ ERR getbfcpy(U8* pbdest, const U8* pb, size_t cb, size_t ofs, U32 n)
 {
     ERR err = WMP_errSuccess;
     FailIf(ofs + n > cb, WMP_errBufferOverflow);
-    memcpy(pbdest, &pb[ofs], n);
+    memmove(pbdest, &pb[ofs], n);
 Cleanup:
     return err;
 }
@@ -114,7 +114,7 @@ ERR setbfcpy(U8* pb, size_t cb, size_t ofs, const U8* pbset, size_t cbset)
 {
     ERR err = WMP_errSuccess;
     FailIf(ofs + cbset > cb, WMP_errBufferOverflow);
-    memcpy(&pb[ofs], pbset, cbset);
+    memmove(&pb[ofs], pbset, cbset);
 Cleanup:
     return err;
 }
@@ -394,7 +394,7 @@ ERR BufferCopyIFD(const U8* pbsrc, U32 cbsrc, U32 ofssrc, U8 endian, U8* pbdst, 
             FailIf(ofssrcdata + size > cbsrc || ofsdstdata + size > cbdst, WMP_errBufferOverflow);
             if ( size == count || endian == WMP_INTEL_ENDIAN )
                 // size == count means 8-bit data means endian doesn't matter
-                memcpy(&pbdst[ofsdstdata], &pbsrc[ofssrcdata], size);
+                memmove(&pbdst[ofsdstdata], &pbsrc[ofssrcdata], size);
             else
             {   // big endian source and endian matters
                 U32 j;


### PR DESCRIPTION
Change summary:
- Use `memmove()` rather than `memcpy()` to aid older GLIBC compatibility
- Optimise for size via `-Os`

Around the release of GLIBC 2.13 changes were made to the behaviour of
`memcpy()` and `memmove()` during some 64-bit Intel processor specific
improvements.  This broke certain applications that relied, knowingly or
not, on the previously "undefined" behaviour creating somewhat of an
Ulrich vs. Linus shitstorm:
- https://sourceware.org/bugzilla/show_bug.cgi?id=12518

As such, there are two symbol versions that we can target with GLIBC
2.14+:
- memcpy@GLIBC_2.2.5
- memcpy@GLIBC_2.14

The symantics here are certainly complicated but end the result is the
same: we have an CentOS 6 deployment target, which ships with GLIBC
2.12, and thus can only use the GLIBC 2.2.5 symbol.  As Linus repeatedly
argued on the aforementioned bug, there's really very little reason not
to be using `memmove()`, it's both safer and the performance penalties
are negligable when not working with overlapping areas of memory.

In implementing 90977d3 and looking at the dynamic symbol table of the
resulting shared object the memcpy@GLIBC_2.14 symbol is still referenced
when linking against GLIBC 2.14+ even though it is unused.  This is
because "string.h" exports that symbol and in most cases the compiler
defaults to `-O0` causing "dead" symbols to remain in the dynamic symbol
table.
