### PR TITLE
Adjust the implementation to aid Decode reuse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ CXX_LIBRARIES=$(CXX_STATIC_LIBRARIES)
 endif
 
 LIBS=-L$(DIR_BUILD) $(shell echo $(LIBRARIES) | sed -E 's%$(DIR_BUILD)/lib([^ ]*)\.(a|$(LIBSUFFIX))%-l\1%g') -lm
-CXXLIBS=-L$(DIR_BUILD) -ljxr++
+CXXLIBS=-L$(DIR_BUILD) -ljxr++ -lcrypto
 
 ##--------------------------------
 ##

--- a/cpp/lib/CodecFactory.cpp
+++ b/cpp/lib/CodecFactory.cpp
@@ -104,12 +104,23 @@ namespace jxrlib {
     throw FormatError(msg.str().c_str());
   }
 
-  void CodecFactory::decoderFromBytes(ImageDecoder &decoder, std::vector<unsigned char> data) {
-    decoderFromBytes(decoder, data.data(), data.size());
+  void CodecFactory::decoderFromBytes(ImageDecoder &decoder,
+                                      std::vector<unsigned char> data) {
+    decoderFromBytes(decoder, data.data(), 0, data.size());
   }
 
-  void CodecFactory::decoderFromBytes(ImageDecoder &decoder, unsigned char *bytes, size_t len) {
-    Stream dataStream(bytes, len);
+  void CodecFactory::decoderFromBytes(ImageDecoder &decoder,
+                                      std::vector<unsigned char> data,
+                                      size_t offset,
+                                      size_t length) {
+    decoderFromBytes(decoder, data.data(), 0, length);
+  }
+
+  void CodecFactory::decoderFromBytes(ImageDecoder &decoder,
+                                      unsigned char *bytes,
+                                      size_t offset,
+                                      size_t length) {
+    Stream dataStream(bytes + offset, length);
     const PKIID *pIID = NULL;
 
     Call(GetImageDecodeIID((const char *)".jxr", &pIID));

--- a/cpp/lib/CodecFactory.hpp
+++ b/cpp/lib/CodecFactory.hpp
@@ -37,9 +37,19 @@ namespace jxrlib {
     ~CodecFactory();
 
     void decoderFromFile(ImageDecoder &decoder, std::string inputFile);
-    void decoderFromFile(ImageDecoder &decoder, std::string inputFile, long offset);
-    void decoderFromBytes(ImageDecoder &decoder, std::vector<unsigned char> data);
-    void decoderFromBytes(ImageDecoder &decoder, unsigned char *bytes, size_t len);
+    void decoderFromFile(ImageDecoder &decoder,
+                         std::string inputFile,
+                         long offset);
+    void decoderFromBytes(ImageDecoder &decoder,
+                          std::vector<unsigned char> data);
+    void decoderFromBytes(ImageDecoder &decoder,
+                          std::vector<unsigned char> data,
+                          size_t offset,
+                          size_t length);
+    void decoderFromBytes(ImageDecoder &decoder,
+                          unsigned char *bytes,
+                          size_t offset,
+                          size_t length);
     FormatConverter createFormatConverter(ImageDecoder &decoder,
                                           std::string extension);
   };

--- a/cpp/lib/DecodeContext.cpp
+++ b/cpp/lib/DecodeContext.cpp
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * Copyright (C) 2016 Glencoe Software, Inc. All rights reserved.
+ * %%
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * #%L
+ */
+
+#include "CodecFactory.hpp"
+#include "DecodeContext.hpp"
+#include "ImageDecoder.hpp"
+
+namespace jxrlib {
+
+  void DecodeContext::decodeFirstFrame(char *source,
+                                       char *destination,
+                                       size_t offset,
+                                       size_t length) {
+    ImageDecoder decoder;
+    CodecFactory codecFactory;
+    codecFactory.decoderFromBytes(
+      decoder, (unsigned char *)source, offset, length);
+
+    unsigned int frameSize =
+      decoder.getWidth() * decoder.getHeight() * decoder.getBytesPerPixel();
+    decoder.selectFrame(0);
+    decoder.getRawBytes((unsigned char *)destination);
+  }
+
+} // namespace jxrlib

--- a/cpp/lib/DecodeContext.hpp
+++ b/cpp/lib/DecodeContext.hpp
@@ -1,0 +1,32 @@
+/*
+ * #%L
+ * Copyright (C) 2016 Glencoe Software, Inc. All rights reserved.
+ * %%
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * #%L
+ */
+#pragma once
+
+namespace jxrlib {
+
+  class DecodeContext {
+  public:
+    void decodeFirstFrame(char *source,
+                          char *destination,
+                          size_t offset,
+                          size_t length);
+  };
+
+} // namespace jxrlib

--- a/cpp/vc14projects/JXRWrapCppLib_vc14.vcxproj
+++ b/cpp/vc14projects/JXRWrapCppLib_vc14.vcxproj
@@ -174,6 +174,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\lib\CodecFactory.cpp" />
+    <ClCompile Include="..\lib\DecodeContext.cpp" />
     <ClCompile Include="..\lib\Factory.cpp" />
     <ClCompile Include="..\lib\ImageDecoder.cpp" />
     <ClCompile Include="..\lib\ImageEncoder.cpp" />
@@ -181,6 +182,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\lib\CodecFactory.hpp" />
+    <ClInclude Include="..\lib\DecodeContext.hpp" />
     <ClInclude Include="..\lib\Factory.hpp" />
     <ClInclude Include="..\lib\FormatConverter.hpp" />
     <ClInclude Include="..\lib\FormatError.hpp" />

--- a/java/JXR.i
+++ b/java/JXR.i
@@ -6,6 +6,7 @@
 %include various.i
 %{
   #include "CodecFactory.hpp"
+  #include "DecodeContext.hpp"
   #include "Factory.hpp"
   #include "FormatConverter.hpp"
   #include "FormatError.hpp"
@@ -101,4 +102,8 @@ namespace jxrlib {
   %typemap(javaclassmodifiers) Stream "class"
   struct Stream {};
 
+  class DecodeContext {
+  public:
+    void decodeFirstFrame(char *BYTE, char *BYTE, size_t offset, size_t length) throw(FormatError);
+  };
 }

--- a/java/JXR.i
+++ b/java/JXR.i
@@ -50,9 +50,15 @@ namespace jxrlib {
   %typemap(javaclassmodifiers) CodecFactory "class"
   class CodecFactory {
   public:
-    void decoderFromFile(jxrlib::ImageDecoder& decoder, std::string inputFile) throw(FormatError);
-    void decoderFromBytes(jxrlib::ImageDecoder& decoder, unsigned char *NIOBUFFER, size_t len) throw(FormatError);
-    jxrlib::FormatConverter createFormatConverter(jxrlib::ImageDecoder& decoder, std::string extension) throw(FormatError);
+    void decoderFromFile(jxrlib::ImageDecoder& decoder,
+                         std::string inputFile) throw(FormatError);
+    void decoderFromBytes(jxrlib::ImageDecoder& decoder,
+                          unsigned char *NIOBUFFER,
+                          size_t offset,
+                          size_t length) throw(FormatError);
+    jxrlib::FormatConverter createFormatConverter(
+      jxrlib::ImageDecoder& decoder,
+      std::string extension) throw(FormatError);
   };
 
   %typemap(javaclassmodifiers) Factory "class"

--- a/java/src/main/java/ome/jxrlib/AbstractDecode.java
+++ b/java/src/main/java/ome/jxrlib/AbstractDecode.java
@@ -44,13 +44,18 @@ abstract class AbstractDecode {
     }
 
     public AbstractDecode(ByteBuffer dataBuffer) throws DecodeException {
+        this(dataBuffer, 0, dataBuffer.capacity());
+    }
+
+    public AbstractDecode(ByteBuffer dataBuffer, int offset, int length)
+            throws DecodeException {
         if (!dataBuffer.isDirect()) {
             throw new DecodeException("Buffer must be allocated direct.");
         }
         this.inputFile = null;
         this.dataBuffer = dataBuffer;
         decoder = new ImageDecoder();
-        codecFactory.decoderFromBytes(decoder, dataBuffer, dataBuffer.capacity());
+        codecFactory.decoderFromBytes(decoder, dataBuffer, offset, length);
         frameCount = decoder.getFrameCount();
     }
 

--- a/java/src/main/java/ome/jxrlib/AbstractDecode.java
+++ b/java/src/main/java/ome/jxrlib/AbstractDecode.java
@@ -96,4 +96,11 @@ abstract class AbstractDecode {
         }
     }
 
+    public static byte[] decodeFirstFrame(
+            byte[] source, int offset, int length, int size) {
+        DecodeContext decodeContext = new DecodeContext();
+        byte[] destination = new byte[size];
+        decodeContext.decodeFirstFrame(source, destination, offset, length);
+        return destination;
+    }
 }

--- a/java/src/main/java/ome/jxrlib/Decode.java
+++ b/java/src/main/java/ome/jxrlib/Decode.java
@@ -41,4 +41,9 @@ public class Decode extends AbstractDecode {
         super(dataBuffer);
     }
 
+    public Decode(ByteBuffer dataBuffer, int offset, int length)
+            throws DecodeException {
+        super(dataBuffer, offset, length);
+    }
+
 }

--- a/java/src/test/java/ome/jxrlib/AbstractTest.java
+++ b/java/src/test/java/ome/jxrlib/AbstractTest.java
@@ -27,6 +27,12 @@ import javax.xml.bind.DatatypeConverter;
 abstract class AbstractTest {
 
     String md5(ByteBuffer byteBuffer) {
+        byte[] bytes = new byte[byteBuffer.capacity()];
+        byteBuffer.get(bytes);
+        return md5(bytes);
+    }
+
+    String md5(byte[] bytes) {
         MessageDigest md;
         try {
             md = MessageDigest.getInstance("MD5");
@@ -34,8 +40,6 @@ abstract class AbstractTest {
             // This should never happen
             throw new RuntimeException(e);
         }
-        byte[] bytes = new byte[byteBuffer.capacity()];
-        byteBuffer.get(bytes);
         return DatatypeConverter.printHexBinary(md.digest(bytes)).toLowerCase();
     }
 

--- a/java/src/test/java/ome/jxrlib/TestDecode.java
+++ b/java/src/test/java/ome/jxrlib/TestDecode.java
@@ -39,4 +39,9 @@ public class TestDecode extends AbstractDecode {
         super(dataBuffer);
     }
 
+    public TestDecode(ByteBuffer dataBuffer, int offset, int length)
+            throws DecodeException {
+        super(dataBuffer, offset, length);
+    }
+
 }

--- a/java/src/test/java/ome/jxrlib/TestInMemoryDecode.java
+++ b/java/src/test/java/ome/jxrlib/TestInMemoryDecode.java
@@ -109,6 +109,18 @@ public class TestInMemoryDecode extends AbstractTest {
 
     @Parameters({"filename", "width", "height", "bpp", "md5"})
     @Test
+    public void testFirstFrame(
+        String filename, long width, long height, long bpp, String md5)
+            throws IOException, DecodeException {
+        byte[] data = asByteArray(filename);
+
+        byte[] destination = TestDecode.decodeFirstFrame(
+                data, 0, data.length, (int)(width * height * bpp));
+        Assert.assertEquals(md5, md5(destination));
+    }
+
+    @Parameters({"filename", "width", "height", "bpp", "md5"})
+    @Test
     public void testByteBuffer(
         String filename, long width, long height, long bpp, String md5)
             throws IOException, URISyntaxException, DecodeException {

--- a/java/src/test/java/ome/jxrlib/TestInMemoryDecode.java
+++ b/java/src/test/java/ome/jxrlib/TestInMemoryDecode.java
@@ -87,10 +87,6 @@ public class TestInMemoryDecode extends AbstractTest {
             dataBuffer = ByteBuffer.allocateDirect(offset + length);
             dataBuffer.position(offset);
             channel.read(dataBuffer);
-            System.err.println(
-                    "Offset: " + offset + " Capacity: "
-                    + dataBuffer.capacity() + " Position: "
-                    + dataBuffer.position());
             dataBuffer.position(0);
         }
         return dataBuffer;


### PR DESCRIPTION
It is now easy to memory starve the JVM using a plethora of NIO byte buffers. We need to provide API conveniences such that these buffers can be re-used.
