### PR TITLE
Modify the build.gradle to use the OME Maven and staging repositories

### DIFF
--- a/java/cli/build.gradle
+++ b/java/cli/build.gradle
@@ -16,10 +16,10 @@ repositories {
     jcenter()
     //mavenLocal()
     mavenCentral()
-    omeMaven {
+    maven {
         url 'http://artifacts.openmicroscopy.org/artifactory/maven'
     }
-    omeStaging {
+    maven {
         url 'http://artifacts.openmicroscopy.org/artifactory/ome.staging'
     }
 }

--- a/java/cli/build.gradle
+++ b/java/cli/build.gradle
@@ -16,11 +16,11 @@ repositories {
     jcenter()
     //mavenLocal()
     mavenCentral()
-    maven {
-        url 'http://artifacts.openmicroscopy.org/artifactory/ome.releases'
+    omeMaven {
+        url 'http://artifacts.openmicroscopy.org/artifactory/maven'
     }
-    maven {
-        url 'http://artifacts.openmicroscopy.org/artifactory/ome.snapshots'
+    omeStaging {
+        url 'http://artifacts.openmicroscopy.org/artifactory/ome.staging'
     }
 }
 


### PR DESCRIPTION
Following https://github.com/glencoesoftware/jxrlib/pull/6 and as briefly discussed in https://github.com/glencoesoftware/jxrlib/pull/8#issuecomment-261548429, the OME CI JXRLIB-build has been modified to perform the three following actions:

1. build jxrlib-all using Maven
2. upload the jxrlib-all artifacts to OME artifactory (using `ome.staging` for releases and `ome.snapshots` for SNAPSHOTS)
3. build the cli module using Gradle and run the tests

In its current design, the third step of the build relies on the Java artifacts uploaded in step 2. In the case of release builds, this does not work in the current state of things as uploaded  release artifacts need to be promoted to be available on `ome.releases` and http://artifacts.openmicroscopy.org/artifactory/maven/. This PR proposes a solution to work around this limitation by declaring both the generic OME Maven artifactory URL to retrieve releases and SNAPSHOTS and the `ome.staging` repository to test release `jxrlib-all` artifacts.