### PR TITLE
Bump version number to 0.2.1

### DIFF
--- a/java/all/pom.xml
+++ b/java/all/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>jxrlib-all</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.2.1</version>
   <packaging>jar</packaging>
 
   <name>JXRLib Java Bindings</name>
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>ome</groupId>
       <artifactId>jxrlib</artifactId>
-      <version>0.3.0-SNAPSHOT</version>
+      <version>0.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.scijava</groupId>
@@ -47,19 +47,19 @@
     <dependency>
       <groupId>ome</groupId>
       <artifactId>jxrlib-native-windows_64</artifactId>
-      <version>0.3.0-SNAPSHOT</version>
+      <version>0.2.1</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>ome</groupId>
       <artifactId>jxrlib-native-linux_64</artifactId>
-      <version>0.3.0-SNAPSHOT</version>
+      <version>0.2.1</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>ome</groupId>
       <artifactId>jxrlib-native-osx_64</artifactId>
-      <version>0.3.0-SNAPSHOT</version>
+      <version>0.2.1</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/java/cli/build.gradle
+++ b/java/cli/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'ome.jxrlib-cli'
-version = '0.3.0-SNAPSHOT'
+version = '0.2.1'
 
 mainClassName = 'ome.jxrlib.Main'
 
@@ -30,6 +30,6 @@ configurations.all {
 
 dependencies {
     compile 'ch.qos.logback:logback-classic:1.1.7'
-    compile 'ome:jxrlib-all:0.3.0-SNAPSHOT'
+    compile 'ome:jxrlib-all:0.2.1'
     compile 'args4j:args4j:2.33'
 }

--- a/java/cli/pom.xml
+++ b/java/cli/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>jxrlib-cli</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.2.1</version>
   <packaging>jar</packaging>
 
   <name>JXRLib Command Line Tool</name>
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>ome</groupId>
       <artifactId>jxrlib</artifactId>
-      <version>0.3.0-SNAPSHOT</version>
+      <version>0.2.1</version>
     </dependency>
   </dependencies>
 

--- a/java/native-linux_64/pom.xml
+++ b/java/native-linux_64/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>jxrlib-native-linux_64</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.2.1</version>
   <packaging>jar</packaging>
 
   <name>JXRLib native library dependencies for Linux x86-84</name>

--- a/java/native-osx_64/pom.xml
+++ b/java/native-osx_64/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>jxrlib-native-osx_64</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.2.1</version>
   <packaging>jar</packaging>
 
   <name>JXRLib native library dependencies for Mac OS X x86-84</name>

--- a/java/native-windows_64/pom.xml
+++ b/java/native-windows_64/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>jxrlib-native-windows_64</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.2.1</version>
   <packaging>jar</packaging>
 
   <name>JXRLib native library dependencies for Windows x64</name>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>jxrlib</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.2.1</version>
   <packaging>jar</packaging>
 
   <name>JXRLib Java Bindings</name>


### PR DESCRIPTION
See https://trello.com/c/pUrwD3HA/55-jxrlib-0-2-1-os-x-10-10-and-later

Since [Travis is retiring some Xcode images](https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/), we might want to cut a patch release of `jxrlib`.  Releasing `jxrlib 0.2.1` will set the minimum supported OSX version to 10.10 before we expose it in Bio-Formats 5.3.0. /cc @hflynn 

This way we can also put ourselves in a situation of patching/upgrading jxrlib without impacting the range of supported platforms.