### PR TITLE
Explicitly set xcode version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ matrix:
             - pcre3-dev
       compiler: clang
     - os: osx
-      osx_image: beta-xcode6.2  # Mac OS X 10.9
+      osx_image: xcode6.4  # Mac OS X 10.10
       compiler: gcc
     - os: osx
-      osx_image: beta-xcode6.2  # Mac OS X 10.9
+      osx_image: xcode6.4  # Mac OS X 10.10
       compiler: clang
 
 before_install:


### PR DESCRIPTION
Cherry-picked from #12. This should update the `xcode` version used by the Travis build to pick 6.4 (OSX 10.10 and later)